### PR TITLE
Fix type converters

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ mapped.
 | boolean         | Boolean         |
 | Number          | Long/Double (2) |
 | string          | String          |
-| Array           | Array<Any?> (3) |
+| Array           | List<Any?>      |
 | Set             | Set<Any?>       |
 | Map             | Map<Any?, Any?> |
 | Error           | Error           |
@@ -287,8 +287,6 @@ mapped.
 (1) A Kotlin `Unit` will be mapped to a JavaScript `undefined`, conversely, JavaScript `undefined` won't be mapped to Kotlin `Unit`. 
 
 (2) A `Number` in JavaScript can be cast to an `Int` or a `Float` to match the Kotlin type.
-
-(3) A Kotlin `List` can be mapped to a JavaScript `Array` too.
 
 ### Custom types
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,8 +1,8 @@
 # Benchmark Results
 
-Generated on 6/16/2024, 4:57:02 AM
+Generated on 6/18/2024, 3:47:00 AM
 
-Version: 1.0.0-alpha10
+Version: 1.0.0-alpha11
 
 ### Test environment
 
@@ -16,17 +16,17 @@ Memory: 15.6 GB
 
 | Name | Iterations | Score | Unit |
 | --- | --- | --- | --- |
-| defineDslBindings | 5 | 2208.36 | ops/s |
-| defineReflectionBindings | 5 | 2229.61 | ops/s |
-| invokeDslBindings | 5 | 38556.92 | ops/s |
-| invokeReflectionBindings | 5 | 42065.14 | ops/s |
+| defineDslBindings | 5 | 2221.15 | ops/s |
+| defineReflectionBindings | 5 | 2225.01 | ops/s |
+| invokeDslBindings | 5 | 38466.47 | ops/s |
+| invokeReflectionBindings | 5 | 41658.27 | ops/s |
 
 ### Kotlin/Native Results
 
 | Name | Iterations | Score | Unit |
 | --- | --- | --- | --- |
-| defineDslBindings | 5 | 2138.04 | ops/sec |
-| invokeDslBindings | 5 | 23461.06 | ops/sec |
+| defineDslBindings | 5 | 2140.30 | ops/sec |
+| invokeDslBindings | 5 | 23963.17 | ops/sec |
 
 ### Notes
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ clikt = { module = "com.github.ajalt.clikt:clikt", version = "4.4.0" }
 kotlinx-serialization-properties = { module = "org.jetbrains.kotlinx:kotlinx-serialization-properties", version.ref = "kotlinxSerializationProperties" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
-moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }
+moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
 moshi-kotlin-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
 
 [plugins]

--- a/quickjs-converter-ktxserialization/src/commonMain/kotlin/com/dokar/quickjs/conveter/SerializableConverter.kt
+++ b/quickjs-converter-ktxserialization/src/commonMain/kotlin/com/dokar/quickjs/conveter/SerializableConverter.kt
@@ -16,17 +16,19 @@ import kotlin.reflect.KClass
  */
 @OptIn(ExperimentalSerializationApi::class)
 @Suppress("FunctionName")
-inline fun <reified T : Any> SerializableConverter(): JsObjectConverter<T> {
+inline fun <reified T : Any> SerializableConverter(
+    properties: Properties = Properties
+): JsObjectConverter<T> {
     return object : JsObjectConverter<T> {
         override val targetType: KClass<*> = T::class
 
         override fun convertToTarget(value: JsObject): T {
             val map = value.filterValues { it != null }.mapValues { it.value!! }
-            return Properties.decodeFromMap<T>(map)
+            return properties.decodeFromMap<T>(map)
         }
 
         override fun convertToSource(value: T): JsObject {
-            return Properties.encodeToMap(value).toJsObject()
+            return properties.encodeToMap(value).toJsObject()
         }
     }
 }

--- a/quickjs-converter-ktxserialization/src/commonMain/kotlin/com/dokar/quickjs/conveter/SerializableConverter.kt
+++ b/quickjs-converter-ktxserialization/src/commonMain/kotlin/com/dokar/quickjs/conveter/SerializableConverter.kt
@@ -7,7 +7,8 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.properties.Properties
 import kotlinx.serialization.properties.decodeFromMap
 import kotlinx.serialization.properties.encodeToMap
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
 /**
  * Returns a [JsObjectConverter] for class [T].
@@ -16,11 +17,11 @@ import kotlin.reflect.KClass
  */
 @OptIn(ExperimentalSerializationApi::class)
 @Suppress("FunctionName")
-inline fun <reified T : Any> SerializableConverter(
+inline fun <reified T : Any?> SerializableConverter(
     properties: Properties = Properties
 ): JsObjectConverter<T> {
     return object : JsObjectConverter<T> {
-        override val targetType: KClass<*> = T::class
+        override val targetType: KType = typeOf<T>()
 
         override fun convertToTarget(value: JsObject): T {
             val map = value.filterValues { it != null }.mapValues { it.value!! }

--- a/quickjs-converter-ktxserialization/src/commonTest/kotlin/com/dokar/quickjs/converter/test/SerializableConverterTest.kt
+++ b/quickjs-converter-ktxserialization/src/commonTest/kotlin/com/dokar/quickjs/converter/test/SerializableConverterTest.kt
@@ -4,10 +4,12 @@ import com.dokar.quickjs.binding.asyncFunction
 import com.dokar.quickjs.conveter.SerializableConverter
 import com.dokar.quickjs.quickJs
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+@OptIn(ExperimentalSerializationApi::class)
 class SerializableConverterTest {
     @Test
     fun convertSerializableClasses() = runTest {
@@ -31,7 +33,30 @@ class SerializableConverterTest {
             assertEquals(expected, result)
         }
     }
+
+    @Test
+    fun convertGenericSerializableClasses() = runTest {
+        quickJs {
+            addTypeConverters(
+                SerializableConverter<Wrapper<FetchResponse>>(),
+            )
+
+            val expected = Wrapper(data = FetchResponse(ok = true, body = "Hello"))
+
+            asyncFunction("load") { expected }
+
+            asyncFunction<Wrapper<FetchResponse>?>("loadNullable") { expected }
+
+            assertEquals(expected, evaluate<Wrapper<FetchResponse>>("await load()"))
+            assertEquals(expected, evaluate<Wrapper<FetchResponse>?>("await loadNullable()"))
+        }
+    }
 }
+
+@Serializable
+data class Wrapper<T>(
+    val data: T,
+)
 
 @Serializable
 private data class FetchParams(

--- a/quickjs-converter-ktxserialization/src/commonTest/kotlin/com/dokar/quickjs/converter/test/SerializableConverterTest.kt
+++ b/quickjs-converter-ktxserialization/src/commonTest/kotlin/com/dokar/quickjs/converter/test/SerializableConverterTest.kt
@@ -23,7 +23,8 @@ class SerializableConverterTest {
 
             val result = evaluate<FetchResponse>(
                 """
-                    await fetch({ url: "https://example.com", method: "GET" })
+                    const headers = { "Content-Type": "application/json" };
+                    await fetch({ url: "https://example.com", method: "GET", headers: headers })
                 """.trimIndent()
             )
             val expected = FetchResponse(ok = true, body = "Fetched https://example.com")
@@ -36,6 +37,7 @@ class SerializableConverterTest {
 private data class FetchParams(
     val url: String,
     val method: String,
+    val headers: Map<String, String>,
 )
 
 @Serializable

--- a/quickjs-converter-moshi/build.gradle.kts
+++ b/quickjs-converter-moshi/build.gradle.kts
@@ -23,7 +23,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(project(":quickjs"))
-                implementation(libs.moshi.kotlin)
+                implementation(libs.moshi)
             }
         }
 

--- a/quickjs-converter-moshi/src/commonMain/kotlin/com/dokar/quickjs/conveter/JsonClassConverter.kt
+++ b/quickjs-converter-moshi/src/commonMain/kotlin/com/dokar/quickjs/conveter/JsonClassConverter.kt
@@ -3,10 +3,13 @@ package com.dokar.quickjs.conveter
 import com.dokar.quickjs.binding.JsObject
 import com.dokar.quickjs.binding.toJsObject
 import com.dokar.quickjs.converter.JsObjectConverter
+import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonClass
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapter
-import kotlin.reflect.KClass
+import java.lang.reflect.Type
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
 /**
  * Returns a [JsObjectConverter] for class [T].
@@ -14,13 +17,31 @@ import kotlin.reflect.KClass
  * Required [T] to be annotated with moshi's @[JsonClass].
  */
 @OptIn(ExperimentalStdlibApi::class)
-@Suppress("FunctionName", "UNCHECKED_CAST")
-inline fun <reified T : Any> JsonClassConverter(
+@Suppress("FunctionName")
+inline fun <reified T : Any?> JsonClassConverter(
     moshi: Moshi = Moshi.Builder().build()
 ): JsObjectConverter<T> {
-    val adapter = moshi.adapter<T>()
+    return newConverter(adapter = moshi.adapter())
+}
+
+/**
+ * Returns a [JsObjectConverter] for class [T].
+ *
+ * Required [T] to be annotated with moshi's @[JsonClass].
+ */
+@Suppress("FunctionName")
+inline fun <reified T : Any?> JsonClassConverter(
+    type: Type,
+    moshi: Moshi = Moshi.Builder().build()
+): JsObjectConverter<T> {
+    return newConverter(adapter = moshi.adapter(type))
+}
+
+@Suppress("UNCHECKED_CAST")
+@PublishedApi
+internal inline fun <reified T : Any?> newConverter(adapter: JsonAdapter<T>): JsObjectConverter<T> {
     return object : JsObjectConverter<T> {
-        override val targetType: KClass<*> = T::class
+        override val targetType: KType = typeOf<T>()
 
         override fun convertToTarget(value: JsObject): T {
             return adapter.fromJsonValue(value)

--- a/quickjs-converter-moshi/src/commonMain/kotlin/com/dokar/quickjs/conveter/JsonClassConverter.kt
+++ b/quickjs-converter-moshi/src/commonMain/kotlin/com/dokar/quickjs/conveter/JsonClassConverter.kt
@@ -15,8 +15,10 @@ import kotlin.reflect.KClass
  */
 @OptIn(ExperimentalStdlibApi::class)
 @Suppress("FunctionName", "UNCHECKED_CAST")
-inline fun <reified T : Any> JsonClassConverter(): JsObjectConverter<T> {
-    val adapter = Moshi.Builder().build().adapter<T>()
+inline fun <reified T : Any> JsonClassConverter(
+    moshi: Moshi = Moshi.Builder().build()
+): JsObjectConverter<T> {
+    val adapter = moshi.adapter<T>()
     return object : JsObjectConverter<T> {
         override val targetType: KClass<*> = T::class
 

--- a/quickjs-converter-moshi/src/jvmTest/kotlin/com/dokar/quickjs/converter/test/JsonClassConverterTest.kt
+++ b/quickjs-converter-moshi/src/jvmTest/kotlin/com/dokar/quickjs/converter/test/JsonClassConverterTest.kt
@@ -10,8 +10,7 @@ import kotlin.test.assertEquals
 
 class JsonClassConverterTest {
     @Test
-    fun convertSerializableClasses() = runTest {
-
+    fun convertJsonClassClasses() = runTest {
         quickJs {
             addTypeConverters(
                 JsonClassConverter<FetchParams>(),
@@ -32,7 +31,30 @@ class JsonClassConverterTest {
             assertEquals(expected, result)
         }
     }
+
+    @Test
+    fun convertGenericJsonClassClasses() = runTest {
+        quickJs {
+            addTypeConverters(
+                JsonClassConverter<Wrapper<FetchResponse>>(),
+            )
+
+            val expected = Wrapper(data = FetchResponse(ok = true, body = "Hello"))
+
+            asyncFunction("load") { expected }
+
+            asyncFunction<Wrapper<FetchResponse>?>("loadNullable") { expected }
+
+            assertEquals(expected, evaluate<Wrapper<FetchResponse>>("await load()"))
+            assertEquals(expected, evaluate<Wrapper<FetchResponse>?>("await loadNullable()"))
+        }
+    }
 }
+
+@JsonClass(generateAdapter = true)
+data class Wrapper<T>(
+    val data: T,
+)
 
 @JsonClass(generateAdapter = true)
 internal data class FetchParams(

--- a/quickjs-converter-moshi/src/jvmTest/kotlin/com/dokar/quickjs/converter/test/JsonClassConverterTest.kt
+++ b/quickjs-converter-moshi/src/jvmTest/kotlin/com/dokar/quickjs/converter/test/JsonClassConverterTest.kt
@@ -11,6 +11,7 @@ import kotlin.test.assertEquals
 class JsonClassConverterTest {
     @Test
     fun convertSerializableClasses() = runTest {
+
         quickJs {
             addTypeConverters(
                 JsonClassConverter<FetchParams>(),
@@ -23,7 +24,8 @@ class JsonClassConverterTest {
 
             val result = evaluate<FetchResponse>(
                 """
-                    await fetch({ url: "https://example.com", method: "GET" })
+                    const headers = { "Content-Type": "application/json" };
+                    await fetch({ url: "https://example.com", method: "GET", headers: headers })
                 """.trimIndent()
             )
             val expected = FetchResponse(ok = true, body = "Fetched https://example.com")
@@ -36,6 +38,7 @@ class JsonClassConverterTest {
 internal data class FetchParams(
     val url: String,
     val method: String,
+    val headers: Map<String, String>,
 )
 
 @JsonClass(generateAdapter = true)

--- a/quickjs/native/jni/jni_globals_generated.c
+++ b/quickjs/native/jni/jni_globals_generated.c
@@ -16,6 +16,7 @@ static jclass _cls_throwable = NULL;
 static jclass _cls_set = NULL;
 static jclass _cls_iterator = NULL;
 static jclass _cls_list = NULL;
+static jclass _cls_array_list = NULL;
 static jclass _cls_map = NULL;
 static jclass _cls_map_entry = NULL;
 static jclass _cls_hash_set = NULL;
@@ -53,6 +54,9 @@ static jmethodID _method_iterator_has_next = NULL;
 static jmethodID _method_iterator_next = NULL;
 static jmethodID _method_list_size = NULL;
 static jmethodID _method_list_get = NULL;
+static jmethodID _method_list_add = NULL;
+static jmethodID _method_array_list_init = NULL;
+static jmethodID _method_array_list_init_with_capacity = NULL;
 static jmethodID _method_map_entry_set = NULL;
 static jmethodID _method_map_entry_get_key = NULL;
 static jmethodID _method_map_entry_get_value = NULL;
@@ -190,6 +194,14 @@ jclass cls_list(JNIEnv *env) {
         _cls_list = (*env)->NewGlobalRef(env, cls);
     }
     return _cls_list;
+}
+
+jclass cls_array_list(JNIEnv *env) {
+    if (_cls_array_list == NULL) {
+        jclass cls = (*env)->FindClass(env, "java/util/ArrayList");
+        _cls_array_list = (*env)->NewGlobalRef(env, cls);
+    }
+    return _cls_array_list;
 }
 
 jclass cls_map(JNIEnv *env) {
@@ -448,6 +460,27 @@ jmethodID method_list_get(JNIEnv *env) {
     return _method_list_get;
 }
 
+jmethodID method_list_add(JNIEnv *env) {
+    if (_method_list_add == NULL) {
+        _method_list_add = (*env)->GetMethodID(env, cls_list(env), "add", "(Ljava/lang/Object;)Z");
+    }
+    return _method_list_add;
+}
+
+jmethodID method_array_list_init(JNIEnv *env) {
+    if (_method_array_list_init == NULL) {
+        _method_array_list_init = (*env)->GetMethodID(env, cls_array_list(env), "<init>", "()V");
+    }
+    return _method_array_list_init;
+}
+
+jmethodID method_array_list_init_with_capacity(JNIEnv *env) {
+    if (_method_array_list_init_with_capacity == NULL) {
+        _method_array_list_init_with_capacity = (*env)->GetMethodID(env, cls_array_list(env), "<init>", "(I)V");
+    }
+    return _method_array_list_init_with_capacity;
+}
+
 jmethodID method_map_entry_set(JNIEnv *env) {
     if (_method_map_entry_set == NULL) {
         _method_map_entry_set = (*env)->GetMethodID(env, cls_map(env), "entrySet", "()Ljava/util/Set;");
@@ -659,6 +692,9 @@ void clear_jni_refs_cache(JNIEnv *env) {
     if (_cls_list != NULL) {
         (*env)->DeleteGlobalRef(env, _cls_list);
     }
+    if (_cls_array_list != NULL) {
+        (*env)->DeleteGlobalRef(env, _cls_array_list);
+    }
     if (_cls_map != NULL) {
         (*env)->DeleteGlobalRef(env, _cls_map);
     }
@@ -707,6 +743,7 @@ void clear_jni_refs_cache(JNIEnv *env) {
     _cls_set = NULL;
     _cls_iterator = NULL;
     _cls_list = NULL;
+    _cls_array_list = NULL;
     _cls_map = NULL;
     _cls_map_entry = NULL;
     _cls_hash_set = NULL;
@@ -743,6 +780,9 @@ void clear_jni_refs_cache(JNIEnv *env) {
     _method_iterator_next = NULL;
     _method_list_size = NULL;
     _method_list_get = NULL;
+    _method_list_add = NULL;
+    _method_array_list_init = NULL;
+    _method_array_list_init_with_capacity = NULL;
     _method_map_entry_set = NULL;
     _method_map_entry_get_key = NULL;
     _method_map_entry_get_value = NULL;

--- a/quickjs/native/jni/jni_globals_generated.h
+++ b/quickjs/native/jni/jni_globals_generated.h
@@ -32,6 +32,8 @@ jclass cls_iterator(JNIEnv *env);
 
 jclass cls_list(JNIEnv *env);
 
+jclass cls_array_list(JNIEnv *env);
+
 jclass cls_map(JNIEnv *env);
 
 jclass cls_map_entry(JNIEnv *env);
@@ -101,6 +103,12 @@ jmethodID method_iterator_next(JNIEnv *env);
 jmethodID method_list_size(JNIEnv *env);
 
 jmethodID method_list_get(JNIEnv *env);
+
+jmethodID method_list_add(JNIEnv *env);
+
+jmethodID method_array_list_init(JNIEnv *env);
+
+jmethodID method_array_list_init_with_capacity(JNIEnv *env);
 
 jmethodID method_map_entry_set(JNIEnv *env);
 

--- a/quickjs/src/commonMain/kotlin/com/dokar/quickjs/alias/dslAlias.kt
+++ b/quickjs/src/commonMain/kotlin/com/dokar/quickjs/alias/dslAlias.kt
@@ -11,6 +11,7 @@ import com.dokar.quickjs.binding.asyncFunction
 import com.dokar.quickjs.binding.define
 import com.dokar.quickjs.binding.function
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.jvm.JvmName
 
 /**
  * Alias for [QuickJs.define].
@@ -27,7 +28,10 @@ inline fun QuickJs.def(
  * Alias for [QuickJs.function].
  */
 @ExperimentalQuickJsApi
-inline fun <R> QuickJs.func(name: String, block: FunctionBinding<R>) {
+inline fun <reified R : Any?> QuickJs.func(
+    name: String,
+    crossinline block: (args: Array<Any?>) -> R
+) {
     function(name = name, block = block)
 }
 
@@ -35,6 +39,7 @@ inline fun <R> QuickJs.func(name: String, block: FunctionBinding<R>) {
  * Alias for [QuickJs.function].
  */
 @ExperimentalQuickJsApi
+@JvmName("funcWithTypedArg")
 inline fun <reified T : Any?, reified R : Any?> QuickJs.func(
     name: String,
     crossinline block: (T) -> R
@@ -46,7 +51,10 @@ inline fun <reified T : Any?, reified R : Any?> QuickJs.func(
  * Alias for [QuickJs.asyncFunction].
  */
 @ExperimentalQuickJsApi
-inline fun <R> QuickJs.asyncFunc(name: String, block: AsyncFunctionBinding<R>) {
+inline fun <reified R : Any?> QuickJs.asyncFunc(
+    name: String,
+    crossinline block: suspend (args: Array<Any?>) -> R
+) {
     asyncFunction(name = name, block = block)
 }
 
@@ -54,6 +62,7 @@ inline fun <R> QuickJs.asyncFunc(name: String, block: AsyncFunctionBinding<R>) {
  * Alias for [QuickJs.asyncFunction].
  */
 @ExperimentalQuickJsApi
+@JvmName("asyncFuncWithTypedArg")
 inline fun <reified T : Any?, reified R : Any?> QuickJs.asyncFunc(
     name: String,
     crossinline block: suspend (T) -> R

--- a/quickjs/src/commonMain/kotlin/com/dokar/quickjs/binding/Bindings.dsl.typed.kt
+++ b/quickjs/src/commonMain/kotlin/com/dokar/quickjs/binding/Bindings.dsl.typed.kt
@@ -142,7 +142,7 @@ internal fun canConvertInternally(type: KClass<*>): Boolean {
             type == Float::class || type == Double::class ||
             type == Boolean::class || type == String::class ||
             type == ByteArray::class || type == UByteArray::class ||
-            type == Array::class || type == Collection::class ||
+            type == Array::class || type == List::class ||
             type == Set::class || type == Map::class ||
             type == Error::class || type == JsObject::class
 }

--- a/quickjs/src/commonMain/kotlin/com/dokar/quickjs/binding/Bindings.dsl.typedArg.kt
+++ b/quickjs/src/commonMain/kotlin/com/dokar/quickjs/binding/Bindings.dsl.typedArg.kt
@@ -2,8 +2,10 @@ package com.dokar.quickjs.binding
 
 import com.dokar.quickjs.QuickJs
 import com.dokar.quickjs.converter.TypeConverters
+import com.dokar.quickjs.converter.canConvertReturnInternally
+import com.dokar.quickjs.converter.typeOfInstance
 import com.dokar.quickjs.qjsError
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 
 /**
@@ -11,18 +13,19 @@ import kotlin.reflect.typeOf
  *
  * This function requires a typed parameter [T].
  */
-inline fun <reified T : Any?, reified R : Any?> QuickJs.function(
+inline fun <reified T : Any?, R : Any?> QuickJs.function(
     name: String,
     crossinline block: (T) -> R
 ) {
     defineBinding(
         name = name,
         binding = FunctionBinding { args ->
-            callWithTypedArg<T, R>(
+            callNormalWithTypedArg<T, R>(
                 name = name,
                 typeConverters = typeConverters,
+                argType = typeOf<T>(),
                 args = args,
-                block = block,
+                block = { block(it) },
             )
         },
     )
@@ -33,18 +36,20 @@ inline fun <reified T : Any?, reified R : Any?> QuickJs.function(
  *
  * This function requires a typed parameter [T].
  */
-inline fun <reified T : Any?, reified R : Any?> QuickJs.asyncFunction(
+inline fun <reified T : Any?, R : Any?> QuickJs.asyncFunction(
     name: String,
     crossinline block: suspend (T) -> R
 ) {
     defineBinding(
         name = name,
         binding = AsyncFunctionBinding { args ->
-            callWithTypedArg<T, R>(
+            callSuspendWithTypedArg<T, R>(
                 name = name,
                 typeConverters = typeConverters,
-                args = args
-            ) { block(it) }
+                argType = typeOf<T>(),
+                args = args,
+                block = { block(it) },
+            )
         },
     )
 }
@@ -54,19 +59,20 @@ inline fun <reified T : Any?, reified R : Any?> QuickJs.asyncFunction(
  *
  * This function requires a typed parameter [T].
  */
-inline fun <reified T : Any?, reified R : Any?> ObjectBindingScope.function(
+inline fun <reified T : Any?, R : Any?> ObjectBindingScope.function(
     name: String,
     crossinline block: (T) -> R
 ) {
     function(
         name = name,
         block = { args ->
-            callWithTypedArg<T, R>(
+            callNormalWithTypedArg<T, R>(
                 name = name,
                 // TODO: This is awkward, update it when the context receivers feature is ready.
                 typeConverters = (this as ObjectBindingScopeImpl).typeConverters,
                 args = args,
-                block = block
+                argType = typeOf<T>(),
+                block = { block(it) },
             )
         },
     )
@@ -84,21 +90,57 @@ inline fun <reified T : Any?, reified R : Any?> ObjectBindingScope.asyncFunction
     asyncFunction(
         name = name,
         block = { args ->
-            callWithTypedArg<T, R>(
+            callSuspendWithTypedArg<T, R>(
                 name = name,
                 // TODO: This is awkward, update it when the context receivers feature is ready.
                 typeConverters = (this as ObjectBindingScopeImpl).typeConverters,
-                args = args
-            ) { block(it) }
+                argType = typeOf<T>(),
+                args = args,
+                block = { block(it) },
+            )
         },
     )
 }
 
 @PublishedApi
-internal inline fun <reified T : Any?, reified R : Any?> callWithTypedArg(
+internal fun <T : Any?, R : Any?> callNormalWithTypedArg(
     name: String,
     typeConverters: TypeConverters,
     args: Array<Any?>,
+    argType: KType,
+    block: (T) -> R
+): Any? {
+    return callWithTypedArg(
+        name = name,
+        typeConverters = typeConverters,
+        args = args,
+        argType = argType,
+        block
+    )
+}
+
+@PublishedApi
+internal suspend fun <T : Any?, R : Any?> callSuspendWithTypedArg(
+    name: String,
+    typeConverters: TypeConverters,
+    args: Array<Any?>,
+    argType: KType,
+    block: suspend (T) -> R
+): Any? {
+    return callWithTypedArg<T, R>(
+        name = name,
+        typeConverters = typeConverters,
+        args = args,
+        argType = argType,
+        block = { block(it) }
+    )
+}
+
+private inline fun <T : Any?, R : Any?> callWithTypedArg(
+    name: String,
+    typeConverters: TypeConverters,
+    args: Array<Any?>,
+    argType: KType,
     block: (T) -> R
 ): Any? {
     if (args.isEmpty()) {
@@ -111,38 +153,26 @@ internal inline fun <reified T : Any?, reified R : Any?> callWithTypedArg(
         // Get the typed argument
         typeConverters.convert<Any?, T>(
             source = it,
-            sourceType = it::class,
-            targetType = T::class
+            sourceType = typeOfInstance(typeConverters, it),
+            targetType = argType,
         )
     }
 
-    if (typedArg == null && !typeOf<T>().isMarkedNullable) {
+    if (typedArg == null && !argType.isMarkedNullable) {
         qjsError("Function '$name' requires 1 non-null parameter but null was passed.")
     }
 
-    val result = block(typedArg as T) ?: return null
+    @Suppress("UNCHECKED_CAST")
+    val result = block(typedArg as T)
 
-    if (canConvertInternally(result::class)) {
+    if (canConvertReturnInternally(result)) {
         return result
     }
 
     // Convert result to JsObject
     return typeConverters.convert<R, Any?>(
         source = result,
-        sourceType = result::class,
-        targetType = JsObject::class
+        sourceType = typeOfInstance(typeConverters, result),
+        targetType = typeOf<JsObject>(),
     )
-}
-
-@OptIn(ExperimentalUnsignedTypes::class)
-@PublishedApi
-internal fun canConvertInternally(type: KClass<*>): Boolean {
-    return type == Unit::class ||
-            type == Int::class || type == Long::class ||
-            type == Float::class || type == Double::class ||
-            type == Boolean::class || type == String::class ||
-            type == ByteArray::class || type == UByteArray::class ||
-            type == Array::class || type == List::class ||
-            type == Set::class || type == Map::class ||
-            type == Error::class || type == JsObject::class
 }

--- a/quickjs/src/commonMain/kotlin/com/dokar/quickjs/converter/JsObjectConverter.kt
+++ b/quickjs/src/commonMain/kotlin/com/dokar/quickjs/converter/JsObjectConverter.kt
@@ -1,11 +1,12 @@
 package com.dokar.quickjs.converter
 
 import com.dokar.quickjs.binding.JsObject
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
 /**
  * Converts [JsObject] to the target type [T] and vice versa.
  */
 interface JsObjectConverter<T : Any?> : TypeConverter<JsObject, T> {
-    override val sourceType: KClass<*> get() = JsObject::class
+    override val sourceType: KType get() = typeOf<JsObject>()
 }

--- a/quickjs/src/commonMain/kotlin/com/dokar/quickjs/converter/TypeConverter.kt
+++ b/quickjs/src/commonMain/kotlin/com/dokar/quickjs/converter/TypeConverter.kt
@@ -1,7 +1,7 @@
 package com.dokar.quickjs.converter
 
 import com.dokar.quickjs.QuickJs
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 /**
  * The type converter for custom classes used by [QuickJs]'s functions.
@@ -10,12 +10,12 @@ interface TypeConverter<Source : Any?, Target : Any?> {
     /**
      * The source type class.
      */
-    val sourceType: KClass<*>
+    val sourceType: KType
 
     /**
      * The target type class.
      */
-    val targetType: KClass<*>
+    val targetType: KType
 
     /**
      * Convert a value of type [Source] to type [Target].

--- a/quickjs/src/commonMain/kotlin/com/dokar/quickjs/converter/builtinTypes.kt
+++ b/quickjs/src/commonMain/kotlin/com/dokar/quickjs/converter/builtinTypes.kt
@@ -1,0 +1,77 @@
+package com.dokar.quickjs.converter
+
+import com.dokar.quickjs.binding.JsObject
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
+
+@OptIn(ExperimentalContracts::class)
+@PublishedApi
+internal fun canConvertReturnInternally(instance: Any?): Boolean {
+    contract {
+        returns(false) implies (instance != null)
+    }
+    instance ?: return true
+    return typeOfInstance(instance) != null
+}
+
+@OptIn(ExperimentalUnsignedTypes::class)
+@PublishedApi
+internal fun typeOfClass(typeConverters: TypeConverters, cls: KClass<*>): KType {
+    return when (cls) {
+        Unit::class -> typeOf<Unit>()
+        Int::class -> typeOf<Int>()
+        Long::class -> typeOf<Long>()
+        Float::class -> typeOf<Float>()
+        Double::class -> typeOf<Double>()
+        Boolean::class -> typeOf<Boolean>()
+        String::class -> typeOf<String>()
+        ByteArray::class -> typeOf<ByteArray>()
+        UByteArray::class -> typeOf<UByteArray>()
+        Array::class -> typeOf<Array<*>>()
+        List::class -> typeOf<List<*>>()
+        Set::class -> typeOf<Set<*>>()
+        JsObject::class -> typeOf<JsObject>()
+        Map::class -> typeOf<Map<*, *>>()
+        Error::class -> typeOf<Error>()
+        else -> typeConverters.typeOfClass(cls)
+            ?: throw IllegalStateException(
+                "Cannot find the kotlin type of class '$cls', " +
+                        "did you forget to add a type converter for it?"
+            )
+    }
+}
+
+@PublishedApi
+internal fun typeOfInstance(typeConverters: TypeConverters, instance: Any): KType {
+    return typeOfInstance(instance)
+        ?: typeConverters.typeOfClass(instance::class)
+        ?: throw IllegalStateException(
+            "Cannot find the kotlin type of object $instance (${instance::class}), " +
+                    "did you forget to add a type converter for it?"
+        )
+}
+
+@OptIn(ExperimentalUnsignedTypes::class)
+private fun typeOfInstance(instance: Any): KType? {
+    return when (instance) {
+        Unit -> typeOf<Unit>()
+        is Int -> typeOf<Int>()
+        is Long -> typeOf<Long>()
+        is Float -> typeOf<Float>()
+        is Double -> typeOf<Double>()
+        is Boolean -> typeOf<Boolean>()
+        is String -> typeOf<String>()
+        is ByteArray -> typeOf<ByteArray>()
+        is UByteArray -> typeOf<UByteArray>()
+        is Array<*> -> typeOf<Array<*>>()
+        is List<*> -> typeOf<List<*>>()
+        is Set<*> -> typeOf<Set<*>>()
+        is JsObject -> typeOf<JsObject>()
+        is Map<*, *> -> typeOf<Map<*, *>>()
+        is Error -> typeOf<Error>()
+        else -> null
+    }
+}

--- a/quickjs/src/commonTest/kotlin/com/dokar/quickjs/test/AsyncErrorHandlingTest.kt
+++ b/quickjs/src/commonTest/kotlin/com/dokar/quickjs/test/AsyncErrorHandlingTest.kt
@@ -165,7 +165,7 @@ class AsyncErrorHandlingTest {
             assertFails {
                 evaluate("fetch(); delay();")
             }.also {
-                assertContains(it.message!!, "Cannot convert")
+                assertContains(it.message!!, "Cannot find the kotlin type of object")
             }
             assertFalse(delayed)
         }

--- a/quickjs/src/commonTest/kotlin/com/dokar/quickjs/test/CustomTypeConverterTest.kt
+++ b/quickjs/src/commonTest/kotlin/com/dokar/quickjs/test/CustomTypeConverterTest.kt
@@ -7,7 +7,8 @@ import com.dokar.quickjs.binding.toJsObject
 import com.dokar.quickjs.converter.JsObjectConverter
 import com.dokar.quickjs.quickJs
 import kotlinx.coroutines.test.runTest
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -18,8 +19,8 @@ class CustomTypeConverterTest {
             addTypeConverters(FetchParamsConverter, FetchResponseConverter)
 
             function<FetchParams, FetchResponse>("fetchSync") { args ->
-                val (url, method) = args
-                FetchResponse(ok = true, body = "Hello from ${args.url}")
+                val (url) = args
+                FetchResponse(ok = true, body = "Hello from $url")
             }
 
             asyncFunction<FetchParams, FetchResponse>("fetch") { args ->
@@ -56,7 +57,7 @@ private data class FetchResponse(
 )
 
 private object FetchParamsConverter : JsObjectConverter<FetchParams> {
-    override val targetType: KClass<*> = FetchParams::class
+    override val targetType: KType = typeOf<FetchParams>()
 
     override fun convertToTarget(value: JsObject): FetchParams = FetchParams(
         url = value["url"] as String,
@@ -68,7 +69,7 @@ private object FetchParamsConverter : JsObjectConverter<FetchParams> {
 }
 
 private object FetchResponseConverter : JsObjectConverter<FetchResponse> {
-    override val targetType: KClass<*> = FetchResponse::class
+    override val targetType: KType = typeOf<FetchResponse>()
 
     override fun convertToTarget(value: JsObject): FetchResponse = FetchResponse(
         ok = value["ok"] as Boolean,

--- a/quickjs/src/commonTest/kotlin/com/dokar/quickjs/test/FlowToAsyncIteratorTest.kt
+++ b/quickjs/src/commonTest/kotlin/com/dokar/quickjs/test/FlowToAsyncIteratorTest.kt
@@ -44,7 +44,7 @@ class FlowToAsyncIteratorTest {
                 }
             }
 
-            val result = evaluate<Array<Any?>>(
+            val result = evaluate<List<Any?>>(
                 """
                 async function* numbers() {
                     while (true) {
@@ -64,7 +64,7 @@ class FlowToAsyncIteratorTest {
                 array;
                 """.trimIndent()
             )
-            assertContentEquals(Array(5) { it.toLong() }, result)
+            assertContentEquals(List(5) { it.toLong() }, result)
         }
     }
 }

--- a/quickjs/src/commonTest/kotlin/com/dokar/quickjs/test/TypeMappingTest.kt
+++ b/quickjs/src/commonTest/kotlin/com/dokar/quickjs/test/TypeMappingTest.kt
@@ -36,7 +36,7 @@ class TypeMappingTest {
             assertEquals(1.0, evaluate("""1.0"""))
             assertEquals(1.1, evaluate("""1.1"""))
             // Array
-            assertContentEquals(arrayOf<Any?>(0L, 1L, null), evaluate("[0, 1, null]"))
+            assertContentEquals(listOf<Any?>(0L, 1L, null), evaluate("[0, 1, null]"))
             // Set
             assertEquals(linkedSetOf(0L, 1L), evaluate("new Set([0, 1])"))
             // Map
@@ -78,9 +78,9 @@ class TypeMappingTest {
             assertEquals(1.2f, evaluate("returnsFloat()"))
             assertEquals(1.2, evaluate("returnsDouble()"))
             assertEquals("hello", evaluate("returnsString()"))
-            assertContentEquals(arrayOf<Any?>("hello"), evaluate("returnsArray()"))
+            assertContentEquals(listOf<Any?>("hello"), evaluate("returnsArray()"))
             assertFails { evaluate("returnsUnsupportedArray()") }
-            assertContentEquals(arrayOf<Any?>("hello"), evaluate("returnsList()"))
+            assertContentEquals(listOf<Any?>("hello"), evaluate("returnsList()"))
             assertEquals(setOf("hello"), evaluate("returnsSet()"))
             assertEquals(mapOf("hello" to "world"), evaluate("returnsMap()"))
             assertEquals("world", evaluate("returnsJsObject().hello"))
@@ -131,13 +131,13 @@ class TypeMappingTest {
         quickJs {
             function("arrays") {
                 val arr = it[0]
-                assertTrue(arr is Array<*>)
+                assertTrue(arr is List<*>)
                 assertTrue(arr[0] is Long)
                 assertTrue(arr[1] is Double)
                 assertTrue(arr[2] is Boolean)
                 assertTrue(arr[3] is String)
-                assertTrue(arr[4] is Array<*>)
-                assertTrue((arr[4] as Array<*>).size == 2)
+                assertTrue(arr[4] is List<*>)
+                assertTrue((arr[4] as List<*>).size == 2)
                 assertTrue(arr[5] == null)
                 assertTrue(arr[6] == null)
             }
@@ -369,16 +369,16 @@ class TypeMappingTest {
 
             assertFailsWith<QuickJsException> { evaluate<String>("greet()") }.also {
                 val message = "Function 'greet' requires 1 parameter but none was passed."
-                assertTrue(it.message!!.startsWith(message))
+                assertContains(it.message!!, message)
             }
             assertFailsWith<QuickJsException> { evaluate<String>("greet(1, 2)") }.also {
                 val message = "Function 'greet' requires 1 parameter but 2 were passed."
-                assertTrue(it.message!!.startsWith(message))
+                assertContains(it.message!!, message)
             }
             assertFailsWith<QuickJsException> { evaluate<String>("greet(null)") }.also {
                 val message =
                     "Function 'greet' requires 1 non-null parameter but null was passed."
-                assertTrue(it.message!!.startsWith(message))
+                assertContains(it.message!!, message)
             }
             assertEquals("Hello, null!", evaluate<String>("""nullableGreet(null)"""))
             assertEquals("Hello, Jack!", evaluate<String>("""greet("Jack")"""))

--- a/quickjs/src/jniMain/kotlin/com/dokar/quickjs/alias/dslAlias.jni.kt
+++ b/quickjs/src/jniMain/kotlin/com/dokar/quickjs/alias/dslAlias.jni.kt
@@ -6,6 +6,7 @@ import com.dokar.quickjs.QuickJsException
 import com.dokar.quickjs.binding.JsObjectHandle
 import com.dokar.quickjs.binding.define
 import com.dokar.quickjs.evaluate
+import kotlin.reflect.KType
 
 /**
  * Alias for inline version of [QuickJs.define].
@@ -39,7 +40,7 @@ fun <T> QuickJs.def(
 @Throws(QuickJsException::class)
 suspend fun <T> QuickJs.eval(
     bytecode: ByteArray,
-    type: Class<T>
+    type: KType
 ): T {
     return evaluate(bytecode = bytecode, type = type)
 }
@@ -51,7 +52,7 @@ suspend fun <T> QuickJs.eval(
 @Throws(QuickJsException::class)
 suspend fun <T> QuickJs.eval(
     code: String,
-    type: Class<T>,
+    type: KType,
     filename: String = "main.js",
     asModule: Boolean = false
 ): T {

--- a/quickjs/src/jniMain/kotlin/com/dokar/quickjs/binding/Bindings.reflect.kt
+++ b/quickjs/src/jniMain/kotlin/com/dokar/quickjs/binding/Bindings.reflect.kt
@@ -2,6 +2,8 @@ package com.dokar.quickjs.binding
 
 import com.dokar.quickjs.QuickJs
 import com.dokar.quickjs.QuickJsException
+import com.dokar.quickjs.converter.typeOfClass
+import com.dokar.quickjs.converter.typeOfInstance
 import com.dokar.quickjs.qjsError
 import com.dokar.quickjs.typeConvertOr
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -92,12 +94,12 @@ fun <T> QuickJs.define(
             val parameterTypes = method.parameterTypes
             val parameters = args
                 .mapIndexed { index, param ->
-                    val targetType = parameterTypes[index]
+                    val targetType = typeOfClass(typeConverters, parameterTypes[index].kotlin)
                     typeConvertOr<Any?>(param, targetType) {
                         typeConverters.convert(
                             source = it,
-                            sourceType = it::class,
-                            targetType = targetType.kotlin
+                            sourceType = typeOfInstance(typeConverters, it),
+                            targetType = targetType
                         )
                     }
                 }
@@ -127,12 +129,12 @@ fun <T> QuickJs.define(
             val parameterTypes = method.parameterTypes.slice(0..end)
             val parameters = funcArgs
                 .mapIndexed { index, param ->
-                    val targetType = parameterTypes[index]
+                    val targetType = typeOfClass(typeConverters, parameterTypes[index].kotlin)
                     typeConvertOr<Any?>(param, targetType) {
                         typeConverters.convert(
                             source = it,
-                            sourceType = it::class,
-                            targetType = targetType.kotlin
+                            sourceType = typeOfInstance(typeConverters, it),
+                            targetType = targetType
                         )
                     }
                 }

--- a/quickjs/src/jniMain/kotlin/com/dokar/quickjs/typeConvert.kt
+++ b/quickjs/src/jniMain/kotlin/com/dokar/quickjs/typeConvert.kt
@@ -1,17 +1,21 @@
 package com.dokar.quickjs
 
+import kotlin.reflect.KClass
+import kotlin.reflect.KType
+
 @Suppress("unchecked_cast")
 @PublishedApi
 internal fun <T : Any?> typeConvertOr(
     value: Any?,
-    expectedType: Class<*>,
+    expectedType: KType,
     fallback: (value: Any) -> T
 ): T {
     val nonNull = value ?: return null as T
-    if (expectedType.isInstance(nonNull)) {
+    val expectedCls = expectedType.classifier as KClass<*>
+    if ((expectedCls).isInstance(value)) {
         return nonNull as T
     }
-    when (expectedType) {
+    when (expectedCls.java) {
         Boolean::class.java -> {
             if (value is Boolean) {
                 // Boolean -> boolean

--- a/quickjs/src/jniTest/kotlin/com/dokar/quickjs/test/JsAutoCastingTest.kt
+++ b/quickjs/src/jniTest/kotlin/com/dokar/quickjs/test/JsAutoCastingTest.kt
@@ -1,6 +1,8 @@
 package com.dokar.quickjs.test
 
 import com.dokar.quickjs.typeConvertOr
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
@@ -9,80 +11,80 @@ class JsAutoCastingTest {
     @Test
     fun unboxBooleans() {
         assertEquals(
-            false, typeConvertOrThrow(java.lang.Boolean.valueOf(false), Boolean::class.java)
+            false, typeConvertOrThrow(java.lang.Boolean.valueOf(false), typeOf<Boolean>())
         )
     }
 
     @Test
     fun unboxInts() {
         assertEquals(
-            1, typeConvertOrThrow(Integer.valueOf(1), Int::class.java)
+            1, typeConvertOrThrow(Integer.valueOf(1), typeOf<Int>())
         )
     }
 
     @Test
     fun unboxLongs() {
         assertEquals(
-            1L, typeConvertOrThrow(java.lang.Long.valueOf(1L), Long::class.java)
+            1L, typeConvertOrThrow(java.lang.Long.valueOf(1L), typeOf<Long>())
         )
     }
 
     @Test
     fun unboxFloats() {
         assertEquals(
-            1f, typeConvertOrThrow(java.lang.Float.valueOf(1f), Float::class.java)
+            1f, typeConvertOrThrow(java.lang.Float.valueOf(1f), typeOf<Float>())
         )
     }
 
     @Test
     fun unboxDoubles() {
         assertEquals(
-            1.0, typeConvertOrThrow(java.lang.Double.valueOf(1.0), Double::class.java)
+            1.0, typeConvertOrThrow(java.lang.Double.valueOf(1.0), typeOf<Double>())
         )
     }
 
     @Test
     fun longToFloat() {
-        assertEquals(1f, typeConvertOrThrow(1L, Float::class.java))
+        assertEquals(1f, typeConvertOrThrow(1L, typeOf<Float>()))
     }
 
     @Test
     fun longToDouble() {
-        assertEquals(1.0, typeConvertOrThrow(1L, Double::class.java))
+        assertEquals(1.0, typeConvertOrThrow(1L, typeOf<Double>()))
     }
 
     @Test
     fun longToInt() {
-        assertEquals(1, typeConvertOrThrow(1L, Int::class.java))
-        assertEquals(1, typeConvertOrThrow(1L, java.lang.Integer::class.java))
-        assertEquals(1, typeConvertOrThrow(java.lang.Long.valueOf(1L), Int::class.java))
+        assertEquals(1, typeConvertOrThrow(1L, typeOf<Int>()))
+        assertEquals(1, typeConvertOrThrow(1L, typeOf<java.lang.Integer>()))
+        assertEquals(1, typeConvertOrThrow(java.lang.Long.valueOf(1L), typeOf<Int>()))
         assertEquals(
-            1, typeConvertOrThrow(java.lang.Long.valueOf(1L), java.lang.Integer::class.java)
+            1, typeConvertOrThrow(java.lang.Long.valueOf(1L), typeOf<java.lang.Integer>())
         )
     }
 
     @Test
     fun doubleToFloat() {
-        assertEquals(1f, typeConvertOrThrow(1.0, Float::class.java))
-        assertEquals(1f, typeConvertOrThrow(1.0, java.lang.Float::class.java))
-        assertEquals(1f, typeConvertOrThrow(java.lang.Double.valueOf(1.0), Float::class.java))
+        assertEquals(1f, typeConvertOrThrow(1.0, typeOf<Float>()))
+        assertEquals(1f, typeConvertOrThrow(1.0, typeOf<Float>()))
+        assertEquals(1f, typeConvertOrThrow(java.lang.Double.valueOf(1.0), typeOf<Float>()))
         assertEquals(
-            1f, typeConvertOrThrow(java.lang.Double.valueOf(1.0), java.lang.Float::class.java)
+            1f, typeConvertOrThrow(java.lang.Double.valueOf(1.0), typeOf<java.lang.Float>())
         )
     }
 
     @Test
     fun unsupportedCasting() {
-        assertFails { typeConvertOrThrow("", Float::class.java) }
+        assertFails { typeConvertOrThrow("", typeOf<Float>()) }
         // Not needed since jni won't pass ints
-        assertFails { typeConvertOrThrow(1, Float::class.java) }
-        assertFails { typeConvertOrThrow(1, Long::class.java) }
+        assertFails { typeConvertOrThrow(1, typeOf<Float>()) }
+        assertFails { typeConvertOrThrow(1, typeOf<Long>()) }
     }
 }
 
 private inline fun <reified T : Any?> typeConvertOrThrow(
     value: Any?,
-    expectedType: Class<*>,
+    expectedType: KType,
 ): T {
     Result.success(2).getOrElse { error("") }
     return typeConvertOr<T>(

--- a/quickjs/src/jniTest/kotlin/com/dokar/quickjs/test/ReflectionBindingTest.kt
+++ b/quickjs/src/jniTest/kotlin/com/dokar/quickjs/test/ReflectionBindingTest.kt
@@ -8,7 +8,8 @@ import com.dokar.quickjs.quickJs
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
 import kotlin.coroutines.Continuation
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
@@ -124,11 +125,11 @@ class ReflectionBindingTest {
         fun float(arg: Float) {}
         fun double(arg: Double) {}
         fun string(arg: String) {}
-        fun array(arg: Array<Any?>) {}
+        fun array(arg: List<Any?>) {}
         fun set(arg: Set<*>) {}
         fun map(arg: Map<*, *>) {}
         fun objects(arg: Map<*, *>) {}
-        fun multiple(int: Int, long: Long, float: Float, string: String, arr: Array<*>) {}
+        fun multiple(int: Int, long: Long, float: Float, string: String, arr: List<*>) {}
     }
 
     @Suppress("unused", "UNUSED_PARAMETER")
@@ -170,7 +171,7 @@ class ReflectionBindingTest {
     }
 
     private object FetchParamsConverter : JsObjectConverter<FetchParams> {
-        override val targetType: KClass<*> = FetchParams::class
+        override val targetType: KType = typeOf<FetchParams>()
 
         override fun convertToTarget(value: JsObject): FetchParams = FetchParams(
             url = value["url"] as String,

--- a/quickjs/src/nativeMain/kotlin/com/dokar/quickjs/bridge/jsValueToKtValue.kt
+++ b/quickjs/src/nativeMain/kotlin/com/dokar/quickjs/bridge/jsValueToKtValue.kt
@@ -117,7 +117,7 @@ internal fun CValue<JSValue>.toKtValue(context: CPointer<JSContext>): Any? {
             buffer
         }
     } else if (JS_IsArray(context, this) == 1) {
-        return jsArrayToKtArray(context, this)
+        return jsArrayToKtList(context, this)
     } else if (JS_IsError(context, this) == 1) {
         return jsErrorToKtError(context, this)
     } else if (tag == JS_TAG_OBJECT) {
@@ -247,16 +247,16 @@ private fun jsInt8ArrayToKtByteArray(
 }
 
 @OptIn(ExperimentalForeignApi::class)
-private fun jsArrayToKtArray(
+private fun jsArrayToKtList(
     context: CPointer<JSContext>,
     array: CValue<JSValue>
-): Array<Any?> = memScoped {
+): List<Any?> = memScoped {
     val length = alloc<int64_tVar>()
     JS_GetPropertyStr(context, array, "length").use(context) {
         JS_ToInt64(context, length.ptr, this)
     }
 
-    Array(length.value.toInt()) {
+    List(length.value.toInt()) {
         JS_GetPropertyUint32(context, array, it.toUInt()).use(context) {
             if (this.isTheSameObject(array)) {
                 circularRefError()

--- a/quickjs/src/nativeMain/kotlin/com/dokar/quickjs/typeConvert.kt
+++ b/quickjs/src/nativeMain/kotlin/com/dokar/quickjs/typeConvert.kt
@@ -1,19 +1,21 @@
 package com.dokar.quickjs
 
 import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 @Suppress("unchecked_cast")
 @PublishedApi
 internal fun <T : Any?> typeConvertOr(
     value: Any?,
-    expectedType: KClass<*>,
+    expectedType: KType,
     fallback: (value: Any) -> T
 ): T {
     val nonNull = value ?: return null as T
-    if (expectedType.isInstance(nonNull)) {
+    val expectedClass = expectedType.classifier as KClass<*>
+    if (expectedClass.isInstance(value)) {
         return nonNull as T
     }
-    when (expectedType) {
+    when (expectedClass) {
         Int::class -> {
             when (value) {
                 is Long -> {

--- a/quickjs/src/nativeTest/kotlin/com/dokar/quickjs/test/JsAutoCastingTest.kt
+++ b/quickjs/src/nativeTest/kotlin/com/dokar/quickjs/test/JsAutoCastingTest.kt
@@ -1,7 +1,8 @@
 package com.dokar.quickjs.test
 
 import com.dokar.quickjs.typeConvertOr
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
@@ -10,35 +11,35 @@ class JsAutoCastingTest {
 
     @Test
     fun longToFloat() {
-        assertEquals(1f, typeConvertOrThrow(1L, Float::class))
+        assertEquals(1f, typeConvertOrThrow(1L, typeOf<Float>()))
     }
 
     @Test
     fun longToDouble() {
-        assertEquals(1.0, typeConvertOrThrow(1L, Double::class))
+        assertEquals(1.0, typeConvertOrThrow(1L, typeOf<Double>()))
     }
 
     @Test
     fun longToInt() {
-        assertEquals(1, typeConvertOrThrow(1L, Int::class))
+        assertEquals(1, typeConvertOrThrow(1L, typeOf<Int>()))
     }
 
     @Test
     fun doubleToFloat() {
-        assertEquals(1f, typeConvertOrThrow(1.0, Float::class))
+        assertEquals(1f, typeConvertOrThrow(1.0, typeOf<Float>()))
     }
 
     @Test
     fun unsupportedCasting() {
-        assertFails { typeConvertOrThrow("", Float::class) }
-        assertFails { typeConvertOrThrow(1, Float::class) }
-        assertFails { typeConvertOrThrow(1, Long::class) }
+        assertFails { typeConvertOrThrow("", typeOf<Float>()) }
+        assertFails { typeConvertOrThrow(1, typeOf<Float>()) }
+        assertFails { typeConvertOrThrow(1, typeOf<Long>()) }
     }
 }
 
 private fun <T : Any?> typeConvertOrThrow(
     value: Any?,
-    expectedType: KClass<*>,
+    expectedType: KType,
 ): T {
     return typeConvertOr<T>(
         value,

--- a/scripts/generateJniGlobalsCFiles.mjs
+++ b/scripts/generateJniGlobalsCFiles.mjs
@@ -100,6 +100,14 @@ const JNI_REFS = [
     methods: [
       { name: "size", sign: "()I" },
       { name: "get", sign: "(I)Ljava/lang/Object;" },
+      { name: "add", sign: "(Ljava/lang/Object;)Z"}
+    ],
+  },
+  {
+    className: "java/util/ArrayList",
+    methods: [
+      { name: "<init>", sign: "()V" },
+      { name: "<init>", alias: "init_with_capacity", sign: "(I)V" },
     ],
   },
   {
@@ -228,14 +236,15 @@ function srcClassName(jniName) {
 /**
  * @param {string} jniClassName
  * @param {string} jniName
+ * @param {string} alias Optional alias for the method
  * @returns {string}
  */
-function srcMethodName(jniClassName, jniName) {
+function srcMethodName(jniClassName, jniName, alias) {
   return (
     "method_" +
     camelCaseSnackCase(jniClassName) +
     "_" +
-    camelCaseSnackCase(jniName)
+    camelCaseSnackCase(alias != null ? alias : jniName)
   );
 }
 
@@ -270,7 +279,7 @@ function generateHeader() {
     }
     return acc.concat(
       methods.map((method) => {
-        const name = srcMethodName(className, method.name);
+        const name = srcMethodName(className, method.name, method.alias);
         return `jmethodID ${name}(JNIEnv *env);`;
       })
     );
@@ -350,7 +359,7 @@ function generateSource() {
     }
     return acc.concat(
       methods.map((method) => {
-        const name = srcMethodName(className, method.name);
+        const name = srcMethodName(className, method.name, method.alias);
         return `static jmethodID _${name} = NULL;`;
       })
     );
@@ -364,7 +373,7 @@ function generateSource() {
     const classFunName = srcClassName(className);
     return acc.concat(
       methods.map((method) => {
-        const name = srcMethodName(className, method.name);
+        const name = srcMethodName(className, method.name, method.alias);
         const staticPart = method.isStatic === true ? "Static" : "";
         return `jmethodID ${name}(JNIEnv *env) {
     if (_${name} == NULL) {


### PR DESCRIPTION
This PR brings some **Breaking** changes:

1. Map JS `Array` to Kotlin `List` instead of `Array`, this fixes moshi's `fromJonsValue()`
2. Use `KType` instead of `KClass` in converters, this enables generics support for type converters
3. Due to the previous change, deprecate `evaluate(code, Class<T>)` and similar functions, add `evaluate(code, KType)` as the replacement
