### PR TITLE
Fix concurrent defineBinding race

### DIFF
--- a/quickjs/src/commonTest/kotlin/com/dokar/quickjs/test/ConcurrentDefineBindingStressTest.kt
+++ b/quickjs/src/commonTest/kotlin/com/dokar/quickjs/test/ConcurrentDefineBindingStressTest.kt
@@ -1,0 +1,42 @@
+package com.dokar.quickjs.test
+
+import com.dokar.quickjs.QuickJs
+import com.dokar.quickjs.binding.define
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlin.test.Test
+
+class ConcurrentDefineBindingStressTest {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun concurrentDefineBinding() = runBlocking {
+        repeat(50) { round ->
+            val quickJs = QuickJs.create(UnconfinedTestDispatcher())
+            try {
+                val start = CompletableDeferred<Unit>()
+                val jobs = List(16) { worker ->
+                    launch(Dispatchers.Default) {
+                        start.await()
+                        repeat(200) { index ->
+                            quickJs.define("obj_${round}_${worker}_$index") {
+                                property("value") {
+                                    getter { index }
+                                }
+                                function("call") { worker + index }
+                            }
+                        }
+                    }
+                }
+                start.complete(Unit)
+                jobs.joinAll()
+            } finally {
+                quickJs.close()
+            }
+        }
+    }
+}

--- a/quickjs/src/commonTest/kotlin/com/dokar/quickjs/test/ConcurrentDefineBindingStressTest.kt
+++ b/quickjs/src/commonTest/kotlin/com/dokar/quickjs/test/ConcurrentDefineBindingStressTest.kt
@@ -1,7 +1,9 @@
 package com.dokar.quickjs.test
 
 import com.dokar.quickjs.QuickJs
+import com.dokar.quickjs.binding.asyncFunction
 import com.dokar.quickjs.binding.define
+import com.dokar.quickjs.binding.function
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -9,6 +11,7 @@ import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.withTimeout
 import kotlin.test.Test
 
 class ConcurrentDefineBindingStressTest {
@@ -29,11 +32,19 @@ class ConcurrentDefineBindingStressTest {
                                 }
                                 function("call") { worker + index }
                             }
+                            quickJs.function("fn_${round}_${worker}_$index") {
+                                worker + index
+                            }
+                            quickJs.asyncFunction("async_fn_${round}_${worker}_$index") {
+                                worker + index
+                            }
                         }
                     }
                 }
                 start.complete(Unit)
-                jobs.joinAll()
+                withTimeout(60_000) {
+                    jobs.joinAll()
+                }
             } finally {
                 quickJs.close()
             }

--- a/quickjs/src/jniMain/kotlin/com/dokar/quickjs/QuickJs.jni.kt
+++ b/quickjs/src/jniMain/kotlin/com/dokar/quickjs/QuickJs.jni.kt
@@ -217,41 +217,47 @@ actual class QuickJs private constructor(
         parent: JsObjectHandle,
     ): JsObjectHandle {
         ensureNotClosed()
-        val nativeHandle = defineObject(
-            globals = globals,
-            context = context,
-            parent = parent.nativeHandle,
-            name = name,
-            properties = binding.properties.toTypedArray(),
-            functions = binding.functions.toTypedArray(),
-        )
-        if (nativeHandle < 0L) {
-            throw QuickJsException("Failed to define object '$name'.")
+        jsMutex.withLockSync {
+            val nativeHandle = defineObject(
+                globals = globals,
+                context = context,
+                parent = parent.nativeHandle,
+                name = name,
+                properties = binding.properties.toTypedArray(),
+                functions = binding.functions.toTypedArray(),
+            )
+            if (nativeHandle < 0L) {
+                throw QuickJsException("Failed to define object '$name'.")
+            }
+            objectBindings[nativeHandle] = binding
+            return JsObjectHandle(nativeHandle)
         }
-        objectBindings[nativeHandle] = binding
-        return JsObjectHandle(nativeHandle)
     }
 
     actual fun <R> defineBinding(name: String, binding: FunctionBinding<R>) {
         ensureNotClosed()
-        globalFunctions[name] = binding
-        defineFunction(
-            globals = globals,
-            context = context,
-            name = name,
-            isAsync = false,
-        )
+        jsMutex.withLockSync {
+            globalFunctions[name] = binding
+            defineFunction(
+                globals = globals,
+                context = context,
+                name = name,
+                isAsync = false,
+            )
+        }
     }
 
     actual fun <R> defineBinding(name: String, binding: AsyncFunctionBinding<R>) {
         ensureNotClosed()
-        globalFunctions[name] = binding
-        defineFunction(
-            globals = globals,
-            context = context,
-            name = name,
-            isAsync = true,
-        )
+        jsMutex.withLockSync {
+            globalFunctions[name] = binding
+            defineFunction(
+                globals = globals,
+                context = context,
+                name = name,
+                isAsync = true,
+            )
+        }
     }
 
     @Throws(QuickJsException::class)

--- a/quickjs/src/jniMain/kotlin/com/dokar/quickjs/QuickJs.jni.kt
+++ b/quickjs/src/jniMain/kotlin/com/dokar/quickjs/QuickJs.jni.kt
@@ -216,8 +216,8 @@ actual class QuickJs private constructor(
         binding: ObjectBinding,
         parent: JsObjectHandle,
     ): JsObjectHandle {
-        ensureNotClosed()
-        jsMutex.withLockSync {
+        return jsMutex.withLockSync {
+            ensureNotClosed()
             val nativeHandle = defineObject(
                 globals = globals,
                 context = context,
@@ -230,33 +230,33 @@ actual class QuickJs private constructor(
                 throw QuickJsException("Failed to define object '$name'.")
             }
             objectBindings[nativeHandle] = binding
-            return JsObjectHandle(nativeHandle)
+            JsObjectHandle(nativeHandle)
         }
     }
 
     actual fun <R> defineBinding(name: String, binding: FunctionBinding<R>) {
-        ensureNotClosed()
         jsMutex.withLockSync {
-            globalFunctions[name] = binding
+            ensureNotClosed()
             defineFunction(
                 globals = globals,
                 context = context,
                 name = name,
                 isAsync = false,
             )
+            globalFunctions[name] = binding
         }
     }
 
     actual fun <R> defineBinding(name: String, binding: AsyncFunctionBinding<R>) {
-        ensureNotClosed()
         jsMutex.withLockSync {
-            globalFunctions[name] = binding
+            ensureNotClosed()
             defineFunction(
                 globals = globals,
                 context = context,
                 name = name,
                 isAsync = true,
             )
+            globalFunctions[name] = binding
         }
     }
 
@@ -548,7 +548,9 @@ actual class QuickJs private constructor(
     }
 
     private fun ensureNotClosed() {
-        if (runtime == 0L) qjsError("Already closed.")
+        if (isClosed || runtime == 0L || context == 0L || globals == 0L) {
+            qjsError("Already closed.")
+        }
     }
 
     private external fun newRuntime(): Long

--- a/quickjs/src/nativeMain/kotlin/com/dokar/quickjs/QuickJs.native.kt
+++ b/quickjs/src/nativeMain/kotlin/com/dokar/quickjs/QuickJs.native.kt
@@ -137,14 +137,16 @@ actual class QuickJs private constructor(
         parent: JsObjectHandle
     ): JsObjectHandle {
         ensureNotClosed()
-        val handle = context.defineObject(
-            quickJsRef = ref,
-            parentHandle = parent.nativeHandle,
-            name = name,
-            binding = binding,
-        )
-        objectBindings[handle] = binding
-        return JsObjectHandle(handle)
+        jsMutex.withLockSync {
+            val handle = context.defineObject(
+                quickJsRef = ref,
+                parentHandle = parent.nativeHandle,
+                name = name,
+                binding = binding,
+            )
+            objectBindings[handle] = binding
+            return JsObjectHandle(handle)
+        }
     }
 
     actual fun <R> defineBinding(
@@ -152,14 +154,16 @@ actual class QuickJs private constructor(
         binding: FunctionBinding<R>
     ) {
         ensureNotClosed()
-        context.defineFunction(
-            quickJsRef = ref,
-            parent = null,
-            parentHandle = JsObjectHandle.globalThis.nativeHandle,
-            name = name,
-            isAsync = false,
-        )
-        globalFunctions[name] = binding
+        jsMutex.withLockSync {
+            context.defineFunction(
+                quickJsRef = ref,
+                parent = null,
+                parentHandle = JsObjectHandle.globalThis.nativeHandle,
+                name = name,
+                isAsync = false,
+            )
+            globalFunctions[name] = binding
+        }
     }
 
     actual fun <R> defineBinding(
@@ -167,14 +171,16 @@ actual class QuickJs private constructor(
         binding: AsyncFunctionBinding<R>
     ) {
         ensureNotClosed()
-        context.defineFunction(
-            quickJsRef = ref,
-            parent = null,
-            parentHandle = JsObjectHandle.globalThis.nativeHandle,
-            name = name,
-            isAsync = true,
-        )
-        globalFunctions[name] = binding
+        jsMutex.withLockSync {
+            context.defineFunction(
+                quickJsRef = ref,
+                parent = null,
+                parentHandle = JsObjectHandle.globalThis.nativeHandle,
+                name = name,
+                isAsync = true,
+            )
+            globalFunctions[name] = binding
+        }
     }
 
     @Throws(QuickJsException::class)

--- a/quickjs/src/nativeMain/kotlin/com/dokar/quickjs/QuickJs.native.kt
+++ b/quickjs/src/nativeMain/kotlin/com/dokar/quickjs/QuickJs.native.kt
@@ -136,8 +136,8 @@ actual class QuickJs private constructor(
         binding: ObjectBinding,
         parent: JsObjectHandle
     ): JsObjectHandle {
-        ensureNotClosed()
-        jsMutex.withLockSync {
+        return jsMutex.withLockSync {
+            ensureNotClosed()
             val handle = context.defineObject(
                 quickJsRef = ref,
                 parentHandle = parent.nativeHandle,
@@ -145,7 +145,7 @@ actual class QuickJs private constructor(
                 binding = binding,
             )
             objectBindings[handle] = binding
-            return JsObjectHandle(handle)
+            JsObjectHandle(handle)
         }
     }
 
@@ -153,8 +153,8 @@ actual class QuickJs private constructor(
         name: String,
         binding: FunctionBinding<R>
     ) {
-        ensureNotClosed()
         jsMutex.withLockSync {
+            ensureNotClosed()
             context.defineFunction(
                 quickJsRef = ref,
                 parent = null,
@@ -170,8 +170,8 @@ actual class QuickJs private constructor(
         name: String,
         binding: AsyncFunctionBinding<R>
     ) {
-        ensureNotClosed()
         jsMutex.withLockSync {
+            ensureNotClosed()
             context.defineFunction(
                 quickJsRef = ref,
                 parent = null,
@@ -412,6 +412,7 @@ actual class QuickJs private constructor(
         parentHandle: Long,
         name: String,
     ): Any? {
+        ensureNotClosed()
         val binding = objectBindings[parentHandle] ?: qjsError("Parent not found.")
         return binding.getter(name)
     }
@@ -421,6 +422,7 @@ actual class QuickJs private constructor(
         name: String,
         value: Any?
     ) {
+        ensureNotClosed()
         val binding = objectBindings[parentHandle] ?: qjsError("Parent not found.")
         binding.setter(name, value)
     }
@@ -430,6 +432,7 @@ actual class QuickJs private constructor(
         name: String,
         args: Array<Any?>,
     ): Any? {
+        ensureNotClosed()
         return if (parentHandle == JsObjectHandle.globalThis.nativeHandle) {
             val binding = globalFunctions[name] ?: qjsError("Global function '$name' not found.")
             when (binding) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a stress test for concurrent binding definitions to verify stability under concurrent load.

* **Bug Fixes**
  * Improved thread-safety for binding registration to prevent race conditions during concurrent operations.
  * Tightened runtime/state validation to better detect and handle invalid/closed instances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->