### PR TITLE
Add support for interrupting running evaluations

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,30 @@ const responses = await Promise.all([
 ])
 ```
 
+### Interrupting evaluations
+
+Cancelling the calling coroutine interrupts the evaluation, even if it is busy
+running JavaScript like an infinite loop:
+
+```kotlin
+withTimeout(1000) {
+    quickJs.evaluate<Unit>("while(true){}")
+}
+```
+
+A timeout can also be set on the instance, evaluations running past it will
+throw a `QuickJsInterruptedException`:
+
+```kotlin
+quickJs.evaluationTimeoutMillis = 1000
+```
+
+To interrupt manually from anywhere, call `interruptEvaluation()`:
+
+```kotlin
+quickJs.interruptEvaluation()
+```
+
 ### Modules
 
 [ES Modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) are supported when `evaluate()` or `compile()` has the parameter `asModule = true`.

--- a/quickjs/build.gradle.kts
+++ b/quickjs/build.gradle.kts
@@ -66,6 +66,7 @@ kotlin {
                     headers(
                         file("native/quickjs/quickjs.h"),
                         file("native/common/quickjs_version.h"),
+                        file("native/common/quickjs_interrupt.h"),
                     )
                     packageName("quickjs")
                 }

--- a/quickjs/native/CMakeLists.txt
+++ b/quickjs/native/CMakeLists.txt
@@ -114,6 +114,7 @@ set(quickjs_sources
         "quickjs/libunicode.c"
         "quickjs/quickjs.c"
         "common/quickjs_version.c"
+        "common/quickjs_interrupt.c"
 )
 list(APPEND all_sources ${quickjs_sources})
 

--- a/quickjs/native/common/quickjs_interrupt.c
+++ b/quickjs/native/common/quickjs_interrupt.c
@@ -1,0 +1,77 @@
+#include <stdlib.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <time.h>
+#endif
+
+#include "quickjs.h"
+#include "quickjs_interrupt.h"
+
+typedef struct QjsInterruptState {
+    volatile int requested;
+    volatile int fired;
+    // Monotonic millis, 0 = no deadline
+    volatile int64_t deadline_ms;
+} QjsInterruptState;
+
+static int64_t qjs_now_ms(void) {
+#ifdef _WIN32
+    return (int64_t) GetTickCount64();
+#else
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (int64_t) ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+#endif
+}
+
+static int qjs_interrupt_handler(JSRuntime *rt, void *opaque) {
+    QjsInterruptState *state = (QjsInterruptState *) opaque;
+    if (state == NULL) {
+        return 0;
+    }
+    if (state->requested) {
+        state->fired = 1;
+        return 1;
+    }
+    int64_t deadline = state->deadline_ms;
+    if (deadline > 0 && qjs_now_ms() >= deadline) {
+        state->fired = 1;
+        return 1;
+    }
+    return 0;
+}
+
+void *qjs_interrupt_install(JSRuntime *rt) {
+    QjsInterruptState *state = calloc(1, sizeof(QjsInterruptState));
+    if (state == NULL) {
+        return NULL;
+    }
+    JS_SetInterruptHandler(rt, qjs_interrupt_handler, state);
+    return state;
+}
+
+void qjs_interrupt_free(JSRuntime *rt, void *state) {
+    JS_SetInterruptHandler(rt, NULL, NULL);
+    free(state);
+}
+
+void qjs_interrupt_request(void *state) {
+    if (state != NULL) {
+        ((QjsInterruptState *) state)->requested = 1;
+    }
+}
+
+void qjs_interrupt_reset(void *state, int64_t timeout_ms) {
+    QjsInterruptState *s = state;
+    if (s != NULL) {
+        s->requested = 0;
+        s->fired = 0;
+        s->deadline_ms = timeout_ms > 0 ? qjs_now_ms() + timeout_ms : 0;
+    }
+}
+
+int qjs_interrupt_fired(void *state) {
+    return state != NULL && ((QjsInterruptState *) state)->fired;
+}

--- a/quickjs/native/common/quickjs_interrupt.h
+++ b/quickjs/native/common/quickjs_interrupt.h
@@ -1,0 +1,29 @@
+#ifndef QJS_KT_QUICKJS_INTERRUPT_H
+#define QJS_KT_QUICKJS_INTERRUPT_H
+
+#include <stdint.h>
+
+/*
+ * Evaluation interrupt support on top of JS_SetInterruptHandler().
+ * Requires "quickjs.h" to be included first.
+ *
+ * The handler only reads a few volatile fields, so it's cheap to call on
+ * every check and safe to flag from other threads without locks.
+ */
+
+/* Install the handler after JS_NewRuntime(). Returns the state handle, NULL on OOM. */
+void *qjs_interrupt_install(JSRuntime *rt);
+
+/* Unregister the handler and free the state. Call before JS_FreeRuntime(). */
+void qjs_interrupt_free(JSRuntime *rt, void *state);
+
+/* Abort the running evaluation at its next interrupt check. */
+void qjs_interrupt_request(void *state);
+
+/* Clear the flags and set the deadline to now + timeout_ms (<= 0 for none). */
+void qjs_interrupt_reset(void *state, int64_t timeout_ms);
+
+/* 1 if the handler aborted an evaluation since the last reset. */
+int qjs_interrupt_fired(void *state);
+
+#endif // QJS_KT_QUICKJS_INTERRUPT_H

--- a/quickjs/native/jni/quickjs_jni.c
+++ b/quickjs/native/jni/quickjs_jni.c
@@ -11,6 +11,7 @@
 #include "jobject_to_js_value.h"
 #include "js_value_util.h"
 #include "quickjs_version.h"
+#include "quickjs_interrupt.h"
 #include "promise_rejection_handler.h"
 
 JSRuntime *runtime_from_ptr(JNIEnv *env, jlong ptr) {
@@ -320,6 +321,55 @@ Java_com_dokar_quickjs_QuickJs_setMaxStackSize(JNIEnv *env, jobject this, jlong 
     JS_SetMaxStackSize(runtime, byte_count);
 
     pthread_mutex_unlock(&globals->js_mutex);
+}
+
+/**
+ * Register the interrupt handler, returns the state handle.
+ */
+JNIEXPORT jlong JNICALL
+Java_com_dokar_quickjs_QuickJs_installInterrupt(JNIEnv *env, jobject this, jlong runtime_ptr) {
+    if (runtime_ptr == 0) {
+        return 0;
+    }
+    return (jlong) qjs_interrupt_install((JSRuntime *) runtime_ptr);
+}
+
+/**
+ * Unregister the interrupt handler and free the state.
+ */
+JNIEXPORT void JNICALL
+Java_com_dokar_quickjs_QuickJs_freeInterrupt(JNIEnv *env, jobject this, jlong runtime_ptr,
+                                             jlong state_ptr) {
+    if (runtime_ptr == 0 || state_ptr == 0) {
+        return;
+    }
+    qjs_interrupt_free((JSRuntime *) runtime_ptr, (void *) state_ptr);
+}
+
+/**
+ * Request the running evaluation to be interrupted. No mutex and no throwing
+ * here: called from cancellation handlers while an eval blocks the js thread.
+ */
+JNIEXPORT void JNICALL
+Java_com_dokar_quickjs_QuickJs_requestInterrupt(JNIEnv *env, jobject this, jlong state_ptr) {
+    qjs_interrupt_request((void *) state_ptr);
+}
+
+/**
+ * Reset the interrupt flags and deadline (now + timeout_millis, <= 0 for none).
+ */
+JNIEXPORT void JNICALL
+Java_com_dokar_quickjs_QuickJs_resetInterrupt(JNIEnv *env, jobject this, jlong state_ptr,
+                                              jlong timeout_millis) {
+    qjs_interrupt_reset((void *) state_ptr, timeout_millis);
+}
+
+/**
+ * Whether the interrupt handler aborted an evaluation since the last reset.
+ */
+JNIEXPORT jboolean JNICALL
+Java_com_dokar_quickjs_QuickJs_wasInterrupted(JNIEnv *env, jobject this, jlong state_ptr) {
+    return qjs_interrupt_fired((void *) state_ptr) ? JNI_TRUE : JNI_FALSE;
 }
 
 /**

--- a/quickjs/src/commonMain/kotlin/com/dokar/quickjs/QuickJs.kt
+++ b/quickjs/src/commonMain/kotlin/com/dokar/quickjs/QuickJs.kt
@@ -74,6 +74,26 @@ expect class QuickJs {
     val memoryUsage: MemoryUsage
 
     /**
+     * Timeout in milliseconds for a single evaluation, disabled when zero or
+     * negative (the default).
+     *
+     * An evaluation running past this throws [QuickJsInterruptedException].
+     * Only time spent executing JavaScript counts; to also bound time awaited
+     * in async function bindings, wrap the call in `withTimeout {}`.
+     */
+    var evaluationTimeoutMillis: Long
+
+    /**
+     * Interrupt the running evaluation, failing it with a
+     * [QuickJsInterruptedException]. Works even on busy JavaScript like an
+     * infinite loop, can be called from any thread, and does nothing when no
+     * evaluation is running.
+     *
+     * Cancelling the coroutine that called [evaluate] has the same effect.
+     */
+    fun interruptEvaluation()
+
+    /**
      * Add type converters to extend the type mapping on function parameters,
      * function returns, and [evaluate] results.
      */

--- a/quickjs/src/commonMain/kotlin/com/dokar/quickjs/QuickJsException.kt
+++ b/quickjs/src/commonMain/kotlin/com/dokar/quickjs/QuickJsException.kt
@@ -3,9 +3,17 @@ package com.dokar.quickjs
 /**
  * It can be thrown when initializing [QuickJs] or calling its functions.
  */
-class QuickJsException(
+open class QuickJsException(
     override val message: String?,
 ) : Exception()
+
+/**
+ * Thrown when an evaluation was interrupted by [QuickJs.interruptEvaluation]
+ * or it ran longer than [QuickJs.evaluationTimeoutMillis].
+ */
+class QuickJsInterruptedException(
+    message: String?,
+) : QuickJsException(message)
 
 @PublishedApi
 internal fun qjsError(message: String): Nothing = throw QuickJsException(message)

--- a/quickjs/src/commonTest/kotlin/com/dokar/quickjs/test/EvaluationInterruptTest.kt
+++ b/quickjs/src/commonTest/kotlin/com/dokar/quickjs/test/EvaluationInterruptTest.kt
@@ -1,0 +1,92 @@
+package com.dokar.quickjs.test
+
+import com.dokar.quickjs.QuickJs
+import com.dokar.quickjs.QuickJsInterruptedException
+import com.dokar.quickjs.binding.function
+import com.dokar.quickjs.quickJs
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class EvaluationInterruptTest {
+    @Test
+    fun withTimeoutInterruptsInfiniteLoop() = runTest {
+        withContext(Dispatchers.Default) {
+            quickJs {
+                assertFailsWith<TimeoutCancellationException> {
+                    withTimeout(500) { evaluate<Unit>("while(true){}", "test.js") }
+                }
+                assertEquals(2, evaluate<Int>("1 + 1"))
+            }
+        }
+    }
+
+    @Test
+    fun evaluationTimeoutInterruptsInfiniteLoop() = runTest {
+        withContext(Dispatchers.Default) {
+            quickJs {
+                evaluationTimeoutMillis = 500
+                // Fast scripts still complete
+                assertEquals(
+                    499500,
+                    evaluate<Int>("let s = 0; for (let i = 0; i < 1000; i++) s += i; s")
+                )
+                assertFailsWith<QuickJsInterruptedException> {
+                    evaluate<Unit>("while(true){}", "test.js")
+                }
+                assertEquals(2, evaluate<Int>("1 + 1"))
+            }
+        }
+    }
+
+    @Test
+    fun cancellingCoroutineInterruptsInfiniteLoop() = runTest {
+        withContext(Dispatchers.Default) {
+            val quickJs = QuickJs.create(Dispatchers.Default)
+            try {
+                val started = CompletableDeferred<Unit>()
+                quickJs.function("started") { started.complete(Unit) }
+                val evalJob = launch(Dispatchers.Default) {
+                    quickJs.evaluate<Unit>("started(); while(true){}", "test.js")
+                }
+                started.await()
+                evalJob.cancel()
+                // Fails if cancellation didn't stop the native evaluation
+                withTimeout(5_000) { evalJob.join() }
+                assertTrue(evalJob.isCancelled)
+            } finally {
+                quickJs.close()
+            }
+        }
+    }
+
+    @Test
+    fun interruptEvaluationStopsInfiniteLoop() = runTest {
+        withContext(Dispatchers.Default) {
+            val quickJs = QuickJs.create(Dispatchers.Default)
+            try {
+                val started = CompletableDeferred<Unit>()
+                quickJs.function("started") { started.complete(Unit) }
+                val evalJob = launch(Dispatchers.Default) {
+                    assertFailsWith<QuickJsInterruptedException> {
+                        quickJs.evaluate<Unit>("started(); while(true){}", "test.js")
+                    }
+                }
+                started.await()
+                quickJs.interruptEvaluation()
+                withTimeout(5_000) { evalJob.join() }
+                assertEquals(2, quickJs.evaluate<Int>("1 + 1"))
+            } finally {
+                quickJs.close()
+            }
+        }
+    }
+}

--- a/quickjs/src/jniMain/kotlin/com/dokar/quickjs/QuickJs.jni.kt
+++ b/quickjs/src/jniMain/kotlin/com/dokar/quickjs/QuickJs.jni.kt
@@ -20,6 +20,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
@@ -144,6 +146,7 @@ actual class QuickJs private constructor(
     private var globals: Long = 0
     private var runtime: Long = 0
     private var context: Long = 0
+    private var interruptState: Long = 0
 
     private val objectBindings = mutableMapOf<Long, ObjectBinding>()
     private val globalFunctions = mutableMapOf<String, Binding>()
@@ -201,9 +204,17 @@ actual class QuickJs private constructor(
             return getMemoryUsage(runtime, globals)
         }
 
+    actual var evaluationTimeoutMillis: Long = -1L
+
+    actual fun interruptEvaluation() {
+        ensureNotClosed()
+        requestInterrupt(interruptState)
+    }
+
     init {
         try {
             runtime = newRuntime()
+            interruptState = installInterrupt(runtime)
             context = newContext(runtime)
             globals = initGlobals(
                 runtime,
@@ -336,7 +347,26 @@ actual class QuickJs private constructor(
         }
         return rootEvaluationMutex.withLock {
             evalException = null
-            evalInSession(EvaluationSession(), isRoot = true, evalBlock)
+            resetInterrupt(interruptState, evaluationTimeoutMillis)
+            // Cancellation alone can't stop busy JavaScript, so hook it up
+            // to a native interrupt.
+            val interruptOnCancel = Job(coroutineContext.job)
+            interruptOnCancel.invokeOnCompletion { cause ->
+                if (cause is CancellationException && !isClosed) {
+                    requestInterrupt(interruptState)
+                }
+            }
+            try {
+                evalInSession(EvaluationSession(), isRoot = true, evalBlock)
+            } catch (e: QuickJsException) {
+                // Cancellation wins over the interrupt error
+                coroutineContext.ensureActive()
+                if (wasInterrupted(interruptState)) throw QuickJsInterruptedException(e.message)
+                throw e
+            } finally {
+                interruptOnCancel.complete()
+                resetInterrupt(interruptState, 0L)
+            }
         }
     }
 
@@ -419,6 +449,8 @@ actual class QuickJs private constructor(
                 context = 0
             }
             if (runtime != 0L) {
+                freeInterrupt(runtime, interruptState)
+                interruptState = 0
                 releaseRuntime(runtime)
                 runtime = 0
             }
@@ -758,6 +790,16 @@ actual class QuickJs private constructor(
 
     @Throws(QuickJsException::class)
     private external fun setMaxStackSize(runtime: Long, globals: Long, byteCount: Long)
+
+    private external fun installInterrupt(runtime: Long): Long
+
+    private external fun freeInterrupt(runtime: Long, state: Long)
+
+    private external fun requestInterrupt(state: Long)
+
+    private external fun resetInterrupt(state: Long, timeoutMillis: Long)
+
+    private external fun wasInterrupted(state: Long): Boolean
 
     @Throws(QuickJsException::class)
     private external fun getMemoryUsage(runtime: Long, globals: Long): MemoryUsage

--- a/quickjs/src/nativeMain/kotlin/com/dokar/quickjs/QuickJs.native.kt
+++ b/quickjs/src/nativeMain/kotlin/com/dokar/quickjs/QuickJs.native.kt
@@ -21,6 +21,7 @@ import com.dokar.quickjs.converter.TypeConverters
 import com.dokar.quickjs.converter.castValueOr
 import com.dokar.quickjs.converter.typeOfInstance
 import com.dokar.quickjs.util.withLockSync
+import kotlinx.cinterop.COpaquePointer
 import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.ExperimentalForeignApi
@@ -32,6 +33,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
@@ -52,6 +55,11 @@ import quickjs.JS_RunGC
 import quickjs.JS_SetMaxStackSize
 import quickjs.JS_SetMemoryLimit
 import quickjs.JS_UpdateStackTop
+import quickjs.qjs_interrupt_fired
+import quickjs.qjs_interrupt_free
+import quickjs.qjs_interrupt_install
+import quickjs.qjs_interrupt_request
+import quickjs.qjs_interrupt_reset
 import quickjs.quickjs_version
 import kotlin.coroutines.AbstractCoroutineContextElement
 import kotlin.coroutines.CoroutineContext
@@ -70,6 +78,8 @@ actual class QuickJs private constructor(
         ?: qjsError("Failed to create js context.")
 
     private val ref = StableRef.create(this)
+
+    private var interruptState: COpaquePointer? = null
 
     private var evalException: Throwable? = null
     private var currentEvaluationSession: EvaluationSession? = null
@@ -134,7 +144,15 @@ actual class QuickJs private constructor(
             return runtime.ktMemoryUsage()
         }
 
+    actual var evaluationTimeoutMillis: Long = -1L
+
+    actual fun interruptEvaluation() {
+        ensureNotClosed()
+        qjs_interrupt_request(interruptState)
+    }
+
     init {
+        interruptState = qjs_interrupt_install(runtime)
         setPromiseRejectionHandler(ref, runtime)
     }
 
@@ -293,6 +311,8 @@ actual class QuickJs private constructor(
             objectBindings.clear()
             globalFunctions.clear()
             JS_FreeContext(context)
+            qjs_interrupt_free(runtime, interruptState)
+            interruptState = null
             JS_FreeRuntime(runtime)
         }
         modules.clear()
@@ -347,7 +367,28 @@ actual class QuickJs private constructor(
         }
         return rootEvaluationMutex.withLock {
             evalException = null
-            evalInSession(EvaluationSession(), isRoot = true, block)
+            qjs_interrupt_reset(interruptState, evaluationTimeoutMillis)
+            // Cancellation alone can't stop busy JavaScript, so hook it up
+            // to a native interrupt.
+            val interruptOnCancel = Job(coroutineContext.job)
+            interruptOnCancel.invokeOnCompletion { cause ->
+                if (cause is CancellationException && !isClosed) {
+                    qjs_interrupt_request(interruptState)
+                }
+            }
+            try {
+                evalInSession(EvaluationSession(), isRoot = true, block)
+            } catch (e: QuickJsException) {
+                // Cancellation wins over the interrupt error
+                coroutineContext.ensureActive()
+                if (qjs_interrupt_fired(interruptState) != 0) {
+                    throw QuickJsInterruptedException(e.message)
+                }
+                throw e
+            } finally {
+                interruptOnCancel.complete()
+                qjs_interrupt_reset(interruptState, 0L)
+            }
         }
     }
 


### PR DESCRIPTION
There was no way to stop a script once it was running: coroutine
cancellation can't preempt the blocking JS_Eval() call, so something like
'while(true){}' would peg a thread until the process died. JS_SetInterruptHandler() already existed for exactly this, the binding just never exposed it.

Evaluations can now be stopped three ways:

- cancelling the calling coroutine, so withTimeout {} and scope
  cancellation actually kill busy JavaScript
- setting evaluationTimeoutMillis on the instance (<= 0 disables it, the
  default)
- calling interruptEvaluation() from any thread

Interrupted evaluations throw QuickJsInterruptedException, a new subclass
of QuickJsException. When the caller was cancelled, the cancellation wins
instead, so withTimeout {} still throws its usual
TimeoutCancellationException.

Under the hood, a small C helper (quickjs_interrupt.{h,c}, shared by the
JNI and cinterop builds) keeps a volatile flag and a monotonic deadline per
runtime, and the registered handler does nothing but read them - no
JVM/Kotlin calls on the hot path. The state resets at the start and end of
each evaluation, so an interrupt never bleeds into the next one.

Implemented for all targets (JVM/Android via JNI, Kotlin/Native via
cinterop) with a common test suite; JVM and linuxX64 ran locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable evaluation timeouts for JavaScript execution.
  * Added `interruptEvaluation()` to stop running evaluations, including infinite loops.
  * Added `QuickJsInterruptedException` for interrupted or timed-out evaluations.
  * Coroutine cancellation now interrupts active evaluations.
* **Documentation**
  * Added guidance on cancelling, timing out, and manually interrupting evaluations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->