### PR TITLE
Interrupt busy evaluations when closing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 .cxx
 local.properties
 .kotlin
+quickjs/native/-

--- a/quickjs/src/commonMain/kotlin/com/dokar/quickjs/util/Mutex.ext.kt
+++ b/quickjs/src/commonMain/kotlin/com/dokar/quickjs/util/Mutex.ext.kt
@@ -7,10 +7,14 @@ internal inline fun <T> Mutex.withLockSync(
 ): T {
     try {
         while (!this.tryLock()) {
-            // Loop until the lock is available
+            // Loop until the lock is available, giving the holder a chance to
+            // finish instead of burning a whole core while we wait.
+            yieldThread()
         }
         return block()
     } finally {
         this.unlock()
     }
 }
+
+internal expect fun yieldThread()

--- a/quickjs/src/commonTest/kotlin/com/dokar/quickjs/test/CloseWhileEvaluatingTest.kt
+++ b/quickjs/src/commonTest/kotlin/com/dokar/quickjs/test/CloseWhileEvaluatingTest.kt
@@ -5,6 +5,7 @@ import com.dokar.quickjs.QuickJs
 import com.dokar.quickjs.QuickJsException
 import com.dokar.quickjs.binding.asyncFunction
 import com.dokar.quickjs.binding.function
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -16,6 +17,8 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 
@@ -113,10 +116,12 @@ class CloseWhileEvaluatingTest {
             // Tells us JavaScript is really running before we close
             quickJs.function("notifyRunning") { running.complete(Unit) }
 
+            var evalError: Throwable? = null
             val evalJob = launch(Dispatchers.Default) {
                 try {
                     quickJs.evaluate<Any?>("notifyRunning(); while(true) {}")
-                } catch (_: QuickJsException) {
+                } catch (e: Throwable) {
+                    evalError = e
                 }
             }
 
@@ -129,6 +134,10 @@ class CloseWhileEvaluatingTest {
             }
             assertTrue(closed, "close() did not return while JavaScript was busy")
             evalJob.join()
+
+            val error = evalError
+            assertIs<CancellationException>(error)
+            assertEquals("Already closed.", error.message)
         }
     }
 

--- a/quickjs/src/commonTest/kotlin/com/dokar/quickjs/test/CloseWhileEvaluatingTest.kt
+++ b/quickjs/src/commonTest/kotlin/com/dokar/quickjs/test/CloseWhileEvaluatingTest.kt
@@ -4,13 +4,20 @@ package com.dokar.quickjs.test
 import com.dokar.quickjs.QuickJs
 import com.dokar.quickjs.QuickJsException
 import com.dokar.quickjs.binding.asyncFunction
+import com.dokar.quickjs.binding.function
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
 
 // https://github.com/dokar3/quickjs-kt/issues/131
 class CloseWhileEvaluatingTest {
@@ -94,6 +101,33 @@ class CloseWhileEvaluatingTest {
             }
             delay(15) // Try to close exactly during the suspension of the async function returning
             quickJs.close()
+            evalJob.join()
+        }
+    }
+
+    @Test
+    fun closeWhileBusyEvaluating() = runTest {
+        repeat(REPEAT_COUNT) {
+            val quickJs = QuickJs.create(Dispatchers.Default)
+            val running = CompletableDeferred<Unit>()
+            // Tells us JavaScript is really running before we close
+            quickJs.function("notifyRunning") { running.complete(Unit) }
+
+            val evalJob = launch(Dispatchers.Default) {
+                try {
+                    quickJs.evaluate<Any?>("notifyRunning(); while(true) {}")
+                } catch (_: QuickJsException) {
+                }
+            }
+
+            running.await()
+            // close() blocks its caller, so it has to be watched from another
+            // scope, one that we are not waiting on when it gets stuck.
+            val closeJob = CoroutineScope(Dispatchers.Default).launch { quickJs.close() }
+            val closed = withContext(Dispatchers.Default) {
+                withTimeoutOrNull(10.seconds) { closeJob.join() } != null
+            }
+            assertTrue(closed, "close() did not return while JavaScript was busy")
             evalJob.join()
         }
     }

--- a/quickjs/src/jniMain/kotlin/com/dokar/quickjs/QuickJs.jni.kt
+++ b/quickjs/src/jniMain/kotlin/com/dokar/quickjs/QuickJs.jni.kt
@@ -378,6 +378,8 @@ actual class QuickJs private constructor(
             } catch (e: QuickJsException) {
                 // Cancellation wins over the interrupt error
                 coroutineContext.ensureActive()
+                // close() interrupts too, report it like the other close paths
+                if (isClosed) throw CancellationException("Already closed.")
                 if (wasInterrupted()) throw QuickJsInterruptedException(e.message)
                 throw e
             } finally {
@@ -452,6 +454,10 @@ actual class QuickJs private constructor(
             qjsError("Cannot close QuickJs from within a binding callback.")
         }
         if (!closed.compareAndSet(expectedValue = false, newValue = true)) return
+        // A busy evaluation holds the JS lock until it returns, so interrupt it
+        // first. Without this, closing while something like 'while(true){}' is
+        // running would wait forever.
+        requestInterruptIfOpen()
         signalRuntimeProgress()
         jobsMutex.withLockSync {
             asyncJobs.forEach { it.job.cancel() }

--- a/quickjs/src/jniMain/kotlin/com/dokar/quickjs/util/Mutex.ext.jni.kt
+++ b/quickjs/src/jniMain/kotlin/com/dokar/quickjs/util/Mutex.ext.jni.kt
@@ -1,0 +1,5 @@
+package com.dokar.quickjs.util
+
+internal actual fun yieldThread() {
+    Thread.yield()
+}

--- a/quickjs/src/nativeMain/kotlin/com/dokar/quickjs/QuickJs.native.kt
+++ b/quickjs/src/nativeMain/kotlin/com/dokar/quickjs/QuickJs.native.kt
@@ -311,6 +311,10 @@ actual class QuickJs private constructor(
             qjsError("Cannot close QuickJs from within a binding callback.")
         }
         if (!closed.compareAndSet(expectedValue = false, newValue = true)) return
+        // A busy evaluation holds the JS lock until it returns, so interrupt it
+        // first. Without this, closing while something like 'while(true){}' is
+        // running would wait forever.
+        requestInterruptIfOpen()
         val promisesToFree = jobsMutex.withLockSync {
             evalException = null
             asyncJobs.forEach { it.job.cancel() }
@@ -406,6 +410,8 @@ actual class QuickJs private constructor(
             } catch (e: QuickJsException) {
                 // Cancellation wins over the interrupt error
                 coroutineContext.ensureActive()
+                // close() interrupts too, report it like the other close paths
+                if (isClosed) throw CancellationException("Already closed.")
                 if (wasInterrupted()) {
                     throw QuickJsInterruptedException(e.message)
                 }

--- a/quickjs/src/nativeMain/kotlin/com/dokar/quickjs/util/Mutex.ext.native.kt
+++ b/quickjs/src/nativeMain/kotlin/com/dokar/quickjs/util/Mutex.ext.native.kt
@@ -1,0 +1,7 @@
+package com.dokar.quickjs.util
+
+import platform.posix.sched_yield
+
+internal actual fun yieldThread() {
+    sched_yield()
+}


### PR DESCRIPTION
`close()` waited for the JS lock without interrupting the running evaluation, so
closing during busy JavaScript like `while(true){}` blocked forever.

- `close()` requests an interrupt before waiting for the lock
- `withLockSync` yields instead of hot-spinning while it waits
- an evaluation interrupted by `close()` reports `CancellationException("Already closed.")`, like the other close paths

Tests in `CloseWhileEvaluatingTest` fails in 10s on `main`, passes in 41ms with the fix.

Not sure if this will work for the MacOS and Windows tests, only tested linux. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Closing QuickJS instances now interrupts ongoing busy evaluations promptly instead of blocking indefinitely.
  * Evaluations interrupted by closing now report a consistent cancellation error.
  * Lock handling yields execution while waiting, reducing unnecessary CPU usage and improving responsiveness.
* **Tests**
  * Added coverage verifying that closing an instance completes while JavaScript is stuck in a busy loop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->