### PR TITLE
Support lazy multi-module loading and module bytecode caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,41 +213,63 @@ handle both, otherwise an interrupted evaluation looks like a script error.
 
 ### Modules
 
-[ES Modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) are supported when `evaluate()` or `compile()` has the parameter `asModule = true`.
+[ES Modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) are supported when `evaluate()` or `compile()` uses `asModule = true`.
+
+Create a runtime-scoped `ModuleLoader` to load source on a cache miss and compatible QuickJS bytecode on a cache hit:
 
 ```kotlin
-quickJs {
-    // ...
-    evaluate<String>(
+val sources: Map<String, String> = downloadModuleSources()
+val bytecodeCache = mutableMapOf<String, ByteArray>()
+
+val loader = moduleLoader {
+    load { name ->
+        bytecodeCache[name]
+            ?.let(ModuleContent::Bytecode)
+            ?: sources[name]?.let(ModuleContent::Source)
+    }
+    onCompiled { name, bytecode ->
+        // Update an in-memory cache immediately, then enqueue disk persistence.
+        bytecodeCache[name] = bytecode
+        enqueueModuleBytecodeForPersistence(name, bytecode)
+    }
+}
+
+quickJs(moduleLoader = loader) {
+    var result: Int? = null
+    function("returns") { result = (it.first() as Number).toInt() }
+
+    evaluate<Any?>(
         """
-            import * as hello from "hello";
-            // Use hello
+            import { answer } from "static-answer";
+            const dynamic = await import("dynamic-answer");
+            returns(answer + dynamic.answer);
         """.trimIndent(),
+        filename = "entry",
         asModule = true,
     )
+
+    assertEquals(42, result)
 }
 ```
 
-Modules can be added using `addModule()`  functions, both code and QuickJS bytecode are supported.
+`load()` is called lazily for static and dynamic imports. Source modules loaded into an evaluation context are retained there and delivered to `onCompiled()`; bytecode modules are reused without another compilation callback.
+
+Both loader callbacks run synchronously while QuickJS is resolving a module. Return promptly, do not perform blocking persistence, and do not synchronously re-enter the same `QuickJs` instance. Callback exceptions fail the current compile, graph-resolution, or evaluation operation. The byte array passed to `onCompiled()` remains valid after the callback returns, so it can be handed to an application-owned asynchronous persistence queue.
+
+To inspect the statically reachable modules in an existing entry bytecode without evaluating top-level code, use `resolveModuleGraph()`. It resolves in a temporary context and does not preload the evaluation context, so `onCompiled()` should update the loader's in-memory cache before the method returns:
 
 ```kotlin
-quickJs {
-    val helloModuleCode = """
-        export function greeting() {
-            return "Hi from the hello module!";
-        }
-    """.trimIndent()
-    addModule(name = "hello", code = helloModuleCode)
-    // OR
-    val bytecode = compile(
-        code = helloModuleCode,
-        filename = "hello",
-        asModule = true,
-    )
-    addModule(bytecode)
-    // ...
+quickJs(moduleLoader = loader) {
+    val staticModules = resolveModuleGraph(cachedEntryBytecode)
+    // onCompiled() has populated bytecodeCache for the static source misses.
+    // Dynamic import() targets are loaded later by evaluate().
+    evaluate<Any?>(cachedEntryBytecode)
 }
 ```
+
+Cache keys, source hashes, persistence, eviction, and invalidation are application concerns. QuickJS bytecode is engine-version-specific and must keep the same module name. It is not validated for safety and must only be loaded from a trusted, integrity-protected source; distribute source code instead when content is not trusted. When a module changes or cached bytecode is invalid, create a new `QuickJs` runtime and have the loader return its latest source; `onCompiled()` supplies the replacement bytecode.
+
+The legacy `addModule(name, code)` and `addModule(bytecode)` APIs keep their existing pre-evaluation queue behavior, but are deprecated in favor of `ModuleLoader`.
 
 When evaluating ES module code, no return values will be captured, you may need a function binding to receive the result.
 
@@ -415,7 +437,7 @@ Most of functions may throw:
 
 - `IllegalStateException`, if some function was called after calling `close`
 
-`evaluate()` and `compile()` may throw:
+`evaluate()`, `compile()`, `resolveModuleGraph()`, and `addModule(bytecode)` may throw:
 
 - `QuickJsException`, if a JavaScript error occurred or failed to map a type between JavaScript and Kotlin
 - Other exceptions, if they were occurred in the Kotlin binding

--- a/quickjs/native/jni/module_loader.c
+++ b/quickjs/native/jni/module_loader.c
@@ -1,0 +1,317 @@
+#include <limits.h>
+#include <string.h>
+#include "module_loader.h"
+#include "mapping/jobject_to_js_value.h"
+#include "exception_util.h"
+#include "jni_globals.h"
+
+/**
+ * Converts a pending Java callback failure to a JavaScript error so it follows
+ * QuickJS's normal operation-scoped exception path.
+ */
+static int forward_java_exception(JNIEnv *env,
+                                  JSContext *context,
+                                  const char *message,
+                                  const char *module_name) {
+    jthrowable exception = try_catch_java_exceptions(env);
+    if (exception == NULL) {
+        return 0;
+    }
+
+    JSValue js_error = jobject_to_js_value(env, context, NULL, exception);
+    (*env)->DeleteLocalRef(env, exception);
+    if (JS_IsException(js_error)) {
+        return 1;
+    }
+    if (JS_IsUndefined(js_error)) {
+        JS_ThrowInternalError(context, message, module_name);
+    } else {
+        JS_Throw(context, js_error);
+    }
+    return 1;
+}
+
+/** Serializes a source-compiled module and immediately notifies its owner. */
+static int notify_module_compiled(JNIEnv *env,
+                                  Globals *globals,
+                                  JSContext *context,
+                                  jstring java_name,
+                                  const char *module_name,
+                                  JSValue module) {
+    size_t bytecode_length;
+    uint8_t *bytecode = JS_WriteObject(
+            context,
+            &bytecode_length,
+            module,
+            JS_WRITE_OBJ_BYTECODE | JS_WRITE_OBJ_REFERENCE);
+    if (bytecode == NULL) {
+        JS_ThrowInternalError(context, "Cannot write bytecode for module '%s'.", module_name);
+        return 0;
+    }
+    if (bytecode_length > INT_MAX) {
+        js_free(context, bytecode);
+        JS_ThrowInternalError(context, "Bytecode for module '%s' is too large.", module_name);
+        return 0;
+    }
+
+    jbyteArray java_bytecode = (*env)->NewByteArray(env, (jsize) bytecode_length);
+    if (java_bytecode == NULL) {
+        js_free(context, bytecode);
+        if (!forward_java_exception(
+                env, context,
+                "Cannot allocate bytecode for module '%s'.", module_name)) {
+            JS_ThrowInternalError(
+                    context, "Cannot allocate bytecode for module '%s'.", module_name);
+        }
+        return 0;
+    }
+
+    (*env)->SetByteArrayRegion(
+            env,
+            java_bytecode,
+            0,
+            (jsize) bytecode_length,
+            (jbyte *) bytecode);
+    js_free(context, bytecode);
+    if (forward_java_exception(
+            env, context,
+            "Cannot copy bytecode for module '%s'.", module_name)) {
+        (*env)->DeleteLocalRef(env, java_bytecode);
+        return 0;
+    }
+
+    (*env)->CallVoidMethod(
+            env,
+            globals->module_loader_host,
+            globals->on_module_compiled_method,
+            java_name,
+            java_bytecode);
+    (*env)->DeleteLocalRef(env, java_bytecode);
+    if (forward_java_exception(
+            env, context,
+            "Module compilation callback failed for '%s'.", module_name)) {
+        return 0;
+    }
+    return 1;
+}
+
+/** Reads module bytecode supplied by the host loader. */
+static JSValue read_module_bytecode(JNIEnv *env,
+                                    JSContext *context,
+                                    jbyteArray java_bytecode,
+                                    const char *module_name) {
+    jsize bytecode_length = (*env)->GetArrayLength(env, java_bytecode);
+    if (forward_java_exception(
+            env, context,
+            "Cannot inspect bytecode for module '%s'.", module_name)) {
+        return JS_EXCEPTION;
+    }
+    jbyte *bytecode = (*env)->GetByteArrayElements(env, java_bytecode, NULL);
+    if (bytecode == NULL) {
+        if (!forward_java_exception(
+                env, context,
+                "Cannot read bytecode for module '%s'.", module_name)) {
+            JS_ThrowInternalError(context, "Cannot read bytecode for module '%s'.", module_name);
+        }
+        return JS_EXCEPTION;
+    }
+
+    JSValue module = JS_ReadObject(
+            context,
+            (uint8_t *) bytecode,
+            (size_t) bytecode_length,
+            JS_READ_OBJ_BYTECODE | JS_READ_OBJ_REFERENCE);
+    (*env)->ReleaseByteArrayElements(env, java_bytecode, bytecode, JNI_ABORT);
+    return module;
+}
+
+/** Verifies that cached bytecode belongs to the normalized requested name. */
+static int validate_module_name(JSContext *context,
+                                JSValue module,
+                                const char *requested_name) {
+    JSModuleDef *definition = JS_VALUE_GET_PTR(module);
+    JSAtom name_atom = JS_GetModuleName(context, definition);
+    const char *bytecode_name = JS_AtomToCString(context, name_atom);
+    JS_FreeAtom(context, name_atom);
+    if (bytecode_name == NULL) {
+        JS_ThrowInternalError(context, "Cannot read module bytecode name for '%s'.", requested_name);
+        return 0;
+    }
+    int matches = strcmp(bytecode_name, requested_name) == 0;
+    if (!matches) {
+        JS_ThrowReferenceError(
+                context,
+                "Module bytecode name '%s' does not match '%s'.",
+                bytecode_name,
+                requested_name);
+    }
+    JS_FreeCString(context, bytecode_name);
+    return matches;
+}
+
+/**
+ * Loads source or bytecode from the runtime-scoped Kotlin ModuleLoader.
+
+ */
+static JSModuleDef *load_module(JSContext *context, const char *module_name, void *opaque) {
+    Globals *globals = (Globals *) opaque;
+    JNIEnv *env = get_jni_env();
+    if (env == NULL) {
+        JS_ThrowInternalError(context, "Cannot access JNI while loading module '%s'.", module_name);
+        return NULL;
+    }
+
+    jstring java_name = (*env)->NewStringUTF(env, module_name);
+    if (java_name == NULL) {
+        if (!forward_java_exception(
+                env, context,
+                "Cannot allocate module name '%s'.", module_name)) {
+            JS_ThrowInternalError(context, "Cannot allocate module name '%s'.", module_name);
+        }
+        return NULL;
+    }
+
+    jobject content = (*env)->CallObjectMethod(
+            env,
+            globals->module_loader_host,
+            globals->load_module_method,
+            java_name);
+    if (forward_java_exception(
+            env, context,
+            "Kotlin module loader failed for '%s'.", module_name)) {
+        (*env)->DeleteLocalRef(env, java_name);
+        return NULL;
+    }
+    if (content == NULL) {
+        (*env)->DeleteLocalRef(env, java_name);
+        JS_ThrowReferenceError(context, "could not load module '%s'", module_name);
+        return NULL;
+    }
+
+    jstring java_source = (jstring) (*env)->CallObjectMethod(
+            env,
+            globals->module_loader_host,
+            globals->get_module_source_method,
+            content);
+    if (forward_java_exception(
+            env, context,
+            "Cannot inspect module source for '%s'.", module_name)) {
+        (*env)->DeleteLocalRef(env, content);
+        (*env)->DeleteLocalRef(env, java_name);
+        return NULL;
+    }
+
+    JSValue module = JS_UNDEFINED;
+    if (java_source != NULL) {
+        const char *source = (*env)->GetStringUTFChars(env, java_source, NULL);
+        if (source == NULL) {
+            if (!forward_java_exception(
+                    env, context,
+                    "Cannot read module source '%s'.", module_name)) {
+                JS_ThrowInternalError(context, "Cannot read module source '%s'.", module_name);
+            }
+            (*env)->DeleteLocalRef(env, java_source);
+            (*env)->DeleteLocalRef(env, content);
+            (*env)->DeleteLocalRef(env, java_name);
+            return NULL;
+        }
+        module = JS_Eval(
+                context,
+                source,
+                strlen(source),
+                module_name,
+                JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY);
+        (*env)->ReleaseStringUTFChars(env, java_source, source);
+        (*env)->DeleteLocalRef(env, java_source);
+        if (!JS_IsException(module) && JS_VALUE_GET_TAG(module) == JS_TAG_MODULE &&
+            !notify_module_compiled(
+                    env, globals, context, java_name, module_name, module)) {
+            JS_FreeValue(context, module);
+            module = JS_EXCEPTION;
+        }
+    } else {
+        jbyteArray java_bytecode = (jbyteArray) (*env)->CallObjectMethod(
+                env,
+                globals->module_loader_host,
+                globals->get_module_bytecode_method,
+                content);
+        if (forward_java_exception(
+                env, context,
+                "Cannot inspect module bytecode for '%s'.", module_name)) {
+            (*env)->DeleteLocalRef(env, content);
+            (*env)->DeleteLocalRef(env, java_name);
+            return NULL;
+        }
+        if (java_bytecode == NULL) {
+            (*env)->DeleteLocalRef(env, content);
+            (*env)->DeleteLocalRef(env, java_name);
+            JS_ThrowTypeError(context, "Unsupported module content for '%s'.", module_name);
+            return NULL;
+        }
+        module = read_module_bytecode(env, context, java_bytecode, module_name);
+        (*env)->DeleteLocalRef(env, java_bytecode);
+        if (!JS_IsException(module) && JS_VALUE_GET_TAG(module) == JS_TAG_MODULE &&
+            !validate_module_name(context, module, module_name)) {
+            JS_FreeValue(context, module);
+            module = JS_EXCEPTION;
+        }
+    }
+
+    (*env)->DeleteLocalRef(env, content);
+    (*env)->DeleteLocalRef(env, java_name);
+    if (JS_IsException(module)) {
+        return NULL;
+    }
+    if (JS_VALUE_GET_TAG(module) != JS_TAG_MODULE) {
+        JS_FreeValue(context, module);
+        JS_ThrowTypeError(context, "Content for '%s' is not an ES module.", module_name);
+        return NULL;
+    }
+
+    JSModuleDef *definition = JS_VALUE_GET_PTR(module);
+    JS_FreeValue(context, module);
+    return definition;
+}
+
+int install_module_loader(JNIEnv *env, JSRuntime *runtime, Globals *globals, jobject call_host) {
+    jclass host_class = (*env)->GetObjectClass(env, call_host);
+    if (host_class == NULL) {
+        return 0;
+    }
+    jmethodID load_module_method = (*env)->GetMethodID(
+            env,
+            host_class,
+            "loadModule",
+            "(Ljava/lang/String;)Ljava/lang/Object;");
+    jmethodID get_module_source_method = (*env)->GetMethodID(
+            env,
+            host_class,
+            "getModuleSource",
+            "(Ljava/lang/Object;)Ljava/lang/String;");
+    jmethodID get_module_bytecode_method = (*env)->GetMethodID(
+            env,
+            host_class,
+            "getModuleBytecode",
+            "(Ljava/lang/Object;)[B");
+    jmethodID on_module_compiled_method = (*env)->GetMethodID(
+            env,
+            host_class,
+            "onModuleCompiled",
+            "(Ljava/lang/String;[B)V");
+    (*env)->DeleteLocalRef(env, host_class);
+
+    if (load_module_method == NULL ||
+        get_module_source_method == NULL ||
+        get_module_bytecode_method == NULL ||
+        on_module_compiled_method == NULL) {
+        return 0;
+    }
+
+    globals->module_loader_host = call_host;
+    globals->load_module_method = load_module_method;
+    globals->get_module_source_method = get_module_source_method;
+    globals->get_module_bytecode_method = get_module_bytecode_method;
+    globals->on_module_compiled_method = on_module_compiled_method;
+    JS_SetModuleLoaderFunc(runtime, NULL, load_module, globals);
+    return 1;
+}

--- a/quickjs/native/jni/module_loader.h
+++ b/quickjs/native/jni/module_loader.h
@@ -1,0 +1,16 @@
+#ifndef QJS_KT_MODULE_LOADER_H
+#define QJS_KT_MODULE_LOADER_H
+
+#include "jni.h"
+#include "quickjs.h"
+#include "quickjs_jni.h"
+
+/**
+ * Installs the host-backed module loader for the runtime.
+ *
+ * Returns 1 on success and 0 when a required host method cannot be resolved.
+ * A failed JNI lookup may leave an exception pending for the caller to handle.
+ */
+int install_module_loader(JNIEnv *env, JSRuntime *runtime, Globals *globals, jobject call_host);
+
+#endif //QJS_KT_MODULE_LOADER_H

--- a/quickjs/native/jni/quickjs_jni.c
+++ b/quickjs/native/jni/quickjs_jni.c
@@ -13,6 +13,7 @@
 #include "quickjs_version.h"
 #include "quickjs_interrupt.h"
 #include "promise_rejection_handler.h"
+#include "module_loader.h"
 
 JSRuntime *runtime_from_ptr(JNIEnv *env, jlong ptr) {
     if (ptr == 0) {
@@ -39,6 +40,38 @@ Globals *globals_from_ptr(JNIEnv *env, jlong ptr) {
 }
 
 /**
+ * Releases resources owned by an initGlobals call that cannot return a usable handle.
+ *
+ * Java exceptions must be cleared before entering this function and restored by
+ * the caller after cleanup.
+ */
+static void release_failed_globals_init(JNIEnv *env,
+                                        JSRuntime *runtime,
+                                        Globals *globals) {
+    if (runtime != NULL) {
+        JS_SetHostPromiseRejectionTracker(runtime, NULL, NULL);
+    }
+
+    cvector_vector_type(jobject) global_object_refs = globals->global_object_refs;
+    if (global_object_refs != NULL) {
+        size_t size = cvector_size(global_object_refs);
+        for (uint32_t i = 0; i < size; i++) {
+            if (global_object_refs[i] != NULL) {
+                (*env)->DeleteGlobalRef(env, global_object_refs[i]);
+            }
+        }
+        cvector_free(global_object_refs);
+    }
+
+    pthread_mutex_destroy(&globals->js_mutex);
+    clear_java_vm_cache();
+    if (get_qjs_instance_count() <= 0) {
+        clear_jni_refs_cache(env);
+    }
+    free(globals);
+}
+
+/**
  * Initialize global resources.
  */
 JNIEXPORT jlong JNICALL Java_com_dokar_quickjs_QuickJs_initGlobals(JNIEnv *env,
@@ -50,6 +83,10 @@ JNIEXPORT jlong JNICALL Java_com_dokar_quickjs_QuickJs_initGlobals(JNIEnv *env,
 #pragma ide diagnostic ignored "MemoryLeak"
     Globals *globals = malloc(sizeof(Globals));
 #pragma clang diagnostic pop
+    if (globals == NULL) {
+        jni_throw_qjs_exception(env, "Cannot allocate global resources.");
+        return 0;
+    }
 
     globals->managed_js_values = NULL;
     globals->defined_js_objects = NULL;
@@ -57,6 +94,11 @@ JNIEXPORT jlong JNICALL Java_com_dokar_quickjs_QuickJs_initGlobals(JNIEnv *env,
     globals->created_js_functions = NULL;
     globals->evaluate_result_promises = NULL;
     globals->evaluate_result_active = NULL;
+    globals->module_loader_host = NULL;
+    globals->load_module_method = NULL;
+    globals->get_module_source_method = NULL;
+    globals->get_module_bytecode_method = NULL;
+    globals->on_module_compiled_method = NULL;
 
     pthread_mutexattr_t mutex_attributes;
     pthread_mutexattr_init(&mutex_attributes);
@@ -71,12 +113,60 @@ JNIEXPORT jlong JNICALL Java_com_dokar_quickjs_QuickJs_initGlobals(JNIEnv *env,
     jclass cls_ubyte_array = (*env)->GetObjectArrayElement(env, classes, 1);
     set_cls_ubyte_array(env, cls_ubyte_array);
 
+    jthrowable class_exception = try_catch_java_exceptions(env);
+    if (class_exception != NULL) {
+        release_failed_globals_init(env, NULL, globals);
+        (*env)->Throw(env, class_exception);
+        (*env)->DeleteLocalRef(env, class_exception);
+        return 0;
+    }
+
     JSRuntime *runtime = runtime_from_ptr(env, runtime_ptr);
+    if (runtime == NULL) {
+        jthrowable exception = try_catch_java_exceptions(env);
+        if (exception == NULL) {
+            exception = new_qjs_exception(env, "JS runtime is destroyed.");
+        }
+        release_failed_globals_init(env, NULL, globals);
+        if (exception != NULL) {
+            (*env)->Throw(env, exception);
+            (*env)->DeleteLocalRef(env, exception);
+        }
+        return 0;
+    }
+
     jobject global_host_ref = (*env)->NewGlobalRef(env, this);
+    if (global_host_ref == NULL) {
+        jthrowable exception = try_catch_java_exceptions(env);
+        if (exception == NULL) {
+            exception = new_qjs_exception(
+                    env,
+                    "Cannot allocate module loader host reference.");
+        }
+        release_failed_globals_init(env, runtime, globals);
+        if (exception != NULL) {
+            (*env)->Throw(env, exception);
+            (*env)->DeleteLocalRef(env, exception);
+        }
+        return 0;
+    }
     cvector_push_back(globals->global_object_refs, global_host_ref);
+
     // Handle unhandled promise rejections
     JS_SetHostPromiseRejectionTracker(runtime, promise_rejection_handler,
                                       global_host_ref);
+    if (!install_module_loader(env, runtime, globals, global_host_ref)) {
+        jthrowable exception = try_catch_java_exceptions(env);
+        if (exception == NULL) {
+            exception = new_qjs_exception(env, "Cannot install module loader.");
+        }
+        release_failed_globals_init(env, runtime, globals);
+        if (exception != NULL) {
+            (*env)->Throw(env, exception);
+            (*env)->DeleteLocalRef(env, exception);
+        }
+        return 0;
+    }
 
     return (jlong) globals;
 }
@@ -565,6 +655,105 @@ Java_com_dokar_quickjs_QuickJs_compile(JNIEnv *env, jobject this, jlong context_
 }
 
 /**
+ * Resolves an ES module graph in a temporary context without evaluating it.
+ *
+ * A fresh context ensures every static dependency reaches the runtime loader,
+ * even when the main context already contains modules with the same names.
+ */
+JNIEXPORT jstring JNICALL
+Java_com_dokar_quickjs_QuickJs_resolveModuleGraphBytecode(JNIEnv *env,
+                                                         jobject this,
+                                                         jlong runtime_ptr,
+                                                         jlong globals_ptr,
+                                                         jbyteArray jbuffer) {
+    JSRuntime *runtime = runtime_from_ptr(env, runtime_ptr);
+    Globals *globals = globals_from_ptr(env, globals_ptr);
+    if (runtime == NULL || globals == NULL) {
+        return NULL;
+    }
+
+    jsize buffer_length = (*env)->GetArrayLength(env, jbuffer);
+    jbyte *buffer = (*env)->GetByteArrayElements(env, jbuffer, NULL);
+    if (buffer == NULL) {
+        // Preserve an exception such as OutOfMemoryError raised by the JNI call.
+        if (!(*env)->ExceptionCheck(env)) {
+            jni_throw_qjs_exception(env, "Cannot read ES module entry bytecode.");
+        }
+        return NULL;
+    }
+
+    pthread_mutex_lock(&globals->js_mutex);
+    JSContext *context = JS_NewContext(runtime);
+    if (context == NULL) {
+        (*env)->ReleaseByteArrayElements(env, jbuffer, buffer, JNI_ABORT);
+        pthread_mutex_unlock(&globals->js_mutex);
+        jni_throw_qjs_exception(env, "Cannot create module graph context.");
+        return NULL;
+    }
+    JS_UpdateStackTop(runtime);
+    JSValue entry = JS_ReadObject(
+            context,
+            (uint8_t *) buffer,
+            (size_t) buffer_length,
+            JS_READ_OBJ_BYTECODE | JS_READ_OBJ_REFERENCE);
+    (*env)->ReleaseByteArrayElements(env, jbuffer, buffer, JNI_ABORT);
+
+    if (JS_IsException(entry)) {
+        if (!check_js_context_exception(env, context)) {
+            jni_throw_qjs_exception(env, "Cannot read ES module entry bytecode.");
+        }
+        JS_FreeContext(context);
+        pthread_mutex_unlock(&globals->js_mutex);
+        return NULL;
+    }
+    if (JS_VALUE_GET_TAG(entry) != JS_TAG_MODULE) {
+        JS_FreeValue(context, entry);
+        JS_FreeContext(context);
+        pthread_mutex_unlock(&globals->js_mutex);
+        jni_throw_qjs_exception(env, "Bytecode is not an ES module.");
+        return NULL;
+    }
+
+    JSAtom module_name_atom = JS_GetModuleName(context, JS_VALUE_GET_PTR(entry));
+    const char *module_name = JS_AtomToCString(context, module_name_atom);
+    JS_FreeAtom(context, module_name_atom);
+    if (module_name == NULL) {
+        JS_FreeValue(context, entry);
+        if (!check_js_context_exception(env, context)) {
+            jni_throw_qjs_exception(env, "Cannot read the ES module entry name.");
+        }
+        JS_FreeContext(context);
+        pthread_mutex_unlock(&globals->js_mutex);
+        return NULL;
+    }
+
+    jstring result = (*env)->NewStringUTF(env, module_name);
+    JS_FreeCString(context, module_name);
+    if (result == NULL) {
+        JS_FreeValue(context, entry);
+        JS_FreeContext(context);
+        pthread_mutex_unlock(&globals->js_mutex);
+        return NULL;
+    }
+
+    if (JS_ResolveModule(context, entry) < 0) {
+        JS_FreeValue(context, entry);
+        (*env)->DeleteLocalRef(env, result);
+        if (!check_js_context_exception(env, context)) {
+            jni_throw_qjs_exception(env, "Cannot resolve ES module entry bytecode.");
+        }
+        JS_FreeContext(context);
+        pthread_mutex_unlock(&globals->js_mutex);
+        return NULL;
+    }
+
+    JS_FreeValue(context, entry);
+    JS_FreeContext(context);
+    pthread_mutex_unlock(&globals->js_mutex);
+    return result;
+}
+
+/**
  * Evaluate JavaScript code.
  */
 JNIEXPORT jlong JNICALL
@@ -631,20 +820,33 @@ Java_com_dokar_quickjs_QuickJs_evaluateBytecode(JNIEnv *env, jobject this, jlong
     JS_UpdateStackTop(JS_GetRuntime(context));
 
     // Read buffer
-    JSValue bytecode = JS_ReadObject(context, (uint8_t *) buffer, buf_len, JS_READ_OBJ_BYTECODE);
+    JSValue bytecode = JS_ReadObject(context, (uint8_t *) buffer, buf_len, JS_READ_OBJ_BYTECODE | JS_READ_OBJ_REFERENCE);
     if (JS_IsException(bytecode)) {
-        (*env)->ReleaseByteArrayElements(env, jbuffer, buffer, 0);
-        jni_throw_qjs_exception(env, "Cannot read buffer as bytecode.");
-
+        (*env)->ReleaseByteArrayElements(env, jbuffer, buffer, JNI_ABORT);
+        if (!check_js_context_exception(env, context)) {
+            jni_throw_qjs_exception(env, "Cannot read buffer as bytecode.");
+        }
         pthread_mutex_unlock(&globals->js_mutex);
+        return -1;
+    }
 
+    // Module bytecode only contains dependency names. Resolve the complete graph
+    // before evaluation so QuickJS never observes null dependency pointers.
+    if (JS_VALUE_GET_TAG(bytecode) == JS_TAG_MODULE &&
+        JS_ResolveModule(context, bytecode) < 0) {
+        (*env)->ReleaseByteArrayElements(env, jbuffer, buffer, JNI_ABORT);
+        JS_FreeValue(context, bytecode);
+        if (!check_js_context_exception(env, context)) {
+            jni_throw_qjs_exception(env, "Cannot resolve module bytecode.");
+        }
+        pthread_mutex_unlock(&globals->js_mutex);
         return -1;
     }
 
     // Eval
     JSValue value = JS_EvalFunction(context, bytecode);
 
-    (*env)->ReleaseByteArrayElements(env, jbuffer, buffer, 0);
+    (*env)->ReleaseByteArrayElements(env, jbuffer, buffer, JNI_ABORT);
 
     pthread_mutex_unlock(&globals->js_mutex);
 

--- a/quickjs/native/jni/quickjs_jni.h
+++ b/quickjs/native/jni/quickjs_jni.h
@@ -11,6 +11,18 @@
  */
 typedef struct {
     /**
+     * The owning QuickJs instance used by the synchronous module loader.
+     */
+    jobject module_loader_host;
+    /** QuickJs.loadModule(String) method used by the module loader. */
+    jmethodID load_module_method;
+    /** QuickJs.getModuleSource(Object) content accessor. */
+    jmethodID get_module_source_method;
+    /** QuickJs.getModuleBytecode(Object) content accessor. */
+    jmethodID get_module_bytecode_method;
+    /** QuickJs.onModuleCompiled(String, ByteArray) notification callback. */
+    jmethodID on_module_compiled_method;
+    /**
      * Some JS values, used by C functions.
      */
     cvector_vector_type(JSValue)managed_js_values;

--- a/quickjs/src/commonMain/kotlin/com/dokar/quickjs/ModuleContent.kt
+++ b/quickjs/src/commonMain/kotlin/com/dokar/quickjs/ModuleContent.kt
@@ -1,0 +1,25 @@
+package com.dokar.quickjs
+
+/**
+ * Content returned by [ModuleLoader] when QuickJS resolves an ES module.
+ */
+sealed interface ModuleContent {
+    /**
+     * JavaScript source compiled lazily using the requested module name.
+     *
+     * @param code The complete ES module source.
+     */
+    class Source(val code: String) : ModuleContent
+
+    /**
+     * QuickJS module bytecode reused without recompiling its source.
+     *
+     * The bytecode must be produced by a compatible QuickJS version and retain
+     * the same module name requested from [ModuleLoader.load]. QuickJS does not
+     * validate bytecode for safety, so it must come from a trusted,
+     * integrity-protected source.
+     *
+     * @param bytes The compiled ES module bytecode.
+     */
+    class Bytecode(val bytes: ByteArray) : ModuleContent
+}

--- a/quickjs/src/commonMain/kotlin/com/dokar/quickjs/ModuleLoader.kt
+++ b/quickjs/src/commonMain/kotlin/com/dokar/quickjs/ModuleLoader.kt
@@ -1,0 +1,76 @@
+package com.dokar.quickjs
+
+/**
+ * Supplies ES modules to one [QuickJs] runtime.
+ *
+ * Both callbacks run synchronously while QuickJS is resolving a module. They
+ * must return quickly and must not re-enter the same [QuickJs] instance.
+ */
+fun interface ModuleLoader {
+    /**
+     * Loads a normalized module name requested by QuickJS.
+     *
+     * Return source for a cache miss, compatible bytecode for a cache hit, or
+     * null when the module is unavailable. Unhandled exceptions fail the
+     * current compile, graph-resolution, or evaluation operation.
+     *
+     * @param name The normalized module name.
+     * @return The module content, or null when it cannot be loaded.
+     */
+    fun load(name: String): ModuleContent?
+
+    /**
+     * Reports bytecode immediately after a source module is compiled.
+     *
+     * QuickJs does not retain the Kotlin byte array after this call. Callers may
+     * keep it or enqueue it for asynchronous persistence. Callbacks already
+     * delivered for earlier modules remain valid if later graph resolution
+     * fails. Unhandled exceptions fail the current operation.
+     *
+     * @param name The normalized module name.
+     * @param bytecode The newly compiled module bytecode.
+     */
+    fun onCompiled(name: String, bytecode: ByteArray) = Unit
+}
+
+/**
+ * Configures a [ModuleLoader] with separate load and compilation callbacks.
+ */
+class ModuleLoaderBuilder internal constructor() {
+    private var loadBlock: ((String) -> ModuleContent?)? = null
+    private var onCompiledBlock: (String, ByteArray) -> Unit = { _, _ -> }
+
+    /**
+     * Configures synchronous module lookup.
+     */
+    fun load(block: (name: String) -> ModuleContent?) {
+        loadBlock = block
+    }
+
+    /**
+     * Configures immediate delivery of source-compiled module bytecode.
+     */
+    fun onCompiled(block: (name: String, bytecode: ByteArray) -> Unit) {
+        onCompiledBlock = block
+    }
+
+    internal fun build(): ModuleLoader {
+        val loadCallback = requireNotNull(loadBlock) {
+            "ModuleLoader requires a load callback."
+        }
+        val onCompiledCallback = onCompiledBlock
+        return object : ModuleLoader {
+            override fun load(name: String): ModuleContent? = loadCallback(name)
+
+            override fun onCompiled(name: String, bytecode: ByteArray) {
+                onCompiledCallback(name, bytecode)
+            }
+        }
+    }
+}
+
+/**
+ * Creates a [ModuleLoader] using a small callback DSL.
+ */
+fun moduleLoader(block: ModuleLoaderBuilder.() -> Unit): ModuleLoader =
+    ModuleLoaderBuilder().apply(block).build()

--- a/quickjs/src/commonMain/kotlin/com/dokar/quickjs/QuickJs.kt
+++ b/quickjs/src/commonMain/kotlin/com/dokar/quickjs/QuickJs.kt
@@ -27,12 +27,56 @@ suspend inline fun <T : Any?> quickJs(block: QuickJs.() -> T): T {
 }
 
 /**
+ * DSL for a [QuickJs] runtime backed by [moduleLoader]. The instance is closed
+ * automatically when [block] finishes.
+ *
+ * The dispatcher from the current coroutine context is used for async jobs.
+ *
+ * @param moduleLoader The runtime-scoped ES module loader.
+ */
+@OptIn(ExperimentalStdlibApi::class)
+suspend inline fun <T : Any?> quickJs(
+    moduleLoader: ModuleLoader,
+    block: QuickJs.() -> T,
+): T {
+    val dispatcher = coroutineContext[CoroutineDispatcher]
+        ?: throw UnsupportedOperationException(
+            "The current coroutine context does not have a coroutine context. " +
+                    "Please pass your dispatcher explicitly using another function."
+        )
+    return quickJs(dispatcher, moduleLoader, block)
+}
+
+/**
  * DSL for [QuickJs]. The instance will be closed automatically when the [block] is finished.
  *
  * @param jobDispatcher The dispatcher for executing async jobs.
  */
 inline fun <T : Any?> quickJs(jobDispatcher: CoroutineDispatcher, block: QuickJs.() -> T): T {
     val quickJs = QuickJs.create(jobDispatcher = jobDispatcher)
+    return try {
+        quickJs.block()
+    } finally {
+        quickJs.close()
+    }
+}
+
+/**
+ * DSL for a [QuickJs] runtime backed by [moduleLoader]. The instance is closed
+ * automatically when [block] finishes.
+ *
+ * @param jobDispatcher The dispatcher for executing async jobs.
+ * @param moduleLoader The runtime-scoped ES module loader.
+ */
+inline fun <T : Any?> quickJs(
+    jobDispatcher: CoroutineDispatcher,
+    moduleLoader: ModuleLoader,
+    block: QuickJs.() -> T,
+): T {
+    val quickJs = QuickJs.create(
+        jobDispatcher = jobDispatcher,
+        moduleLoader = moduleLoader,
+    )
     return try {
         quickJs.block()
     } finally {
@@ -140,13 +184,14 @@ expect class QuickJs {
     )
 
     /**
-     * Add a JavaScript module
+     * Add a JavaScript module using the legacy pre-evaluation module queue.
      *
      * @param name The module name.
      * @param code The JavaScript code.
      *
-     * @throws QuickJsException If failed to compile the code.
+     * @throws QuickJsException If the runtime is closed or compilation fails.
      */
+    @Deprecated("Use a ModuleLoader when creating QuickJs instead.")
     @Throws(QuickJsException::class)
     fun addModule(
         name: String,
@@ -154,10 +199,11 @@ expect class QuickJs {
     )
 
     /**
-     * Add a compiled JavaScript module.
+     * Add compiled JavaScript module bytecode to the legacy pre-evaluation queue.
      *
-     * @param bytecode The compiled module bytecode.
+     * @param bytecode The compiled ES module bytecode.
      */
+    @Deprecated("Use a ModuleLoader when creating QuickJs instead.")
     fun addModule(bytecode: ByteArray)
 
     /**
@@ -172,6 +218,23 @@ expect class QuickJs {
      */
     @Throws(QuickJsException::class)
     fun compile(code: String, filename: String = "main.js", asModule: Boolean = false): ByteArray
+
+    /**
+     * Resolves the statically reachable ES module graph without evaluating it.
+     *
+     * Dependencies are supplied by the runtime's [ModuleLoader]. Resolution uses a
+     * temporary context and does not preload the main evaluation context. To avoid
+     * recompiling source during a later [evaluate], [ModuleLoader.onCompiled] should
+     * make its bytecode immediately available to subsequent [ModuleLoader.load]
+     * calls. Dynamic imports are loaded later during evaluation.
+     *
+     * @param entryBytecode Compiled bytecode for the graph entry module.
+     * @return Names observed while resolving the entry and its static dependencies.
+     * @throws QuickJsException If the runtime is closed, bytecode is invalid, or
+     * static dependency resolution fails.
+     */
+    @Throws(QuickJsException::class)
+    fun resolveModuleGraph(entryBytecode: ByteArray): Set<String>
 
     /**
      * Evaluate QuickJS-compiled bytecode.
@@ -228,5 +291,18 @@ expect class QuickJs {
          */
         @Throws(QuickJsException::class)
         fun create(jobDispatcher: CoroutineDispatcher): QuickJs
+
+        /**
+         * Creates a QuickJS runtime backed by [moduleLoader].
+         *
+         * @param jobDispatcher The dispatcher for executing async jobs.
+         * @param moduleLoader The runtime-scoped ES module loader.
+         * @throws QuickJsException If runtime creation fails.
+         */
+        @Throws(QuickJsException::class)
+        fun create(
+            jobDispatcher: CoroutineDispatcher,
+            moduleLoader: ModuleLoader,
+        ): QuickJs
     }
 }

--- a/quickjs/src/commonTest/kotlin/com/dokar/quickjs/test/ModuleLoaderTest.kt
+++ b/quickjs/src/commonTest/kotlin/com/dokar/quickjs/test/ModuleLoaderTest.kt
@@ -1,0 +1,604 @@
+package com.dokar.quickjs.test
+
+import com.dokar.quickjs.ModuleContent
+import com.dokar.quickjs.QuickJsException
+import com.dokar.quickjs.binding.function
+import com.dokar.quickjs.moduleLoader
+import com.dokar.quickjs.quickJs
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class ModuleLoaderTest {
+    @Test
+    fun sourceModulesAreLoadedLazilyAndReportedAfterCompilation() = runTest {
+        val sources = mapOf(
+            "middle" to """
+                import { value } from "leaf";
+                export const result = value * 2;
+            """.trimIndent(),
+            "leaf" to "export const value = 21;",
+            "unused" to "export const value = 100;",
+        )
+        val loaded = mutableListOf<String>()
+        val compiled = linkedMapOf<String, ByteArray>()
+        val loader = moduleLoader {
+            load { name ->
+                loaded += name
+                sources[name]?.let(ModuleContent::Source)
+            }
+            onCompiled { name, bytecode -> compiled[name] = bytecode }
+        }
+
+        var captured = 0
+        quickJs(moduleLoader = loader) {
+            function("capture") { captured = (it.first() as Number).toInt() }
+            evaluate<Any?>(
+                code = "import { result } from 'middle'; capture(result);",
+                filename = "entry",
+                asModule = true,
+            )
+        }
+
+        assertEquals(42, captured)
+        assertEquals(listOf("middle", "leaf"), loaded)
+        assertEquals(setOf("middle", "leaf"), compiled.keys)
+        assertFalse("unused" in compiled)
+    }
+
+    @Test
+    fun cachedBytecodeIsLoadedWithoutCompilationCallback() = runTest {
+        val cached = quickJs {
+            compile(
+                code = "export const value = 42;",
+                filename = "cached",
+                asModule = true,
+            )
+        }
+        var compilationCallbacks = 0
+        val loader = moduleLoader {
+            load { name ->
+                if (name == "cached") ModuleContent.Bytecode(cached) else null
+            }
+            onCompiled { _, _ -> compilationCallbacks++ }
+        }
+
+        var captured = 0
+        quickJs(moduleLoader = loader) {
+            function("capture") { captured = (it.first() as Number).toInt() }
+            evaluate<Any?>(
+                "import { value } from 'cached'; capture(value);",
+                asModule = true,
+            )
+        }
+
+        assertEquals(42, captured)
+        assertEquals(0, compilationCallbacks)
+    }
+
+    @Test
+    fun sourceAndBytecodeModulesCanBeMixedInOneGraph() = runTest {
+        val leafBytecode = quickJs {
+            compile(
+                code = "export const value = 21;",
+                filename = "leaf",
+                asModule = true,
+            )
+        }
+        val compiled = linkedMapOf<String, ByteArray>()
+        val loader = moduleLoader {
+            load { name ->
+                when (name) {
+                    "middle" -> ModuleContent.Source(
+                        "import { value } from 'leaf'; export const result = value * 2;"
+                    )
+                    "leaf" -> ModuleContent.Bytecode(leafBytecode)
+                    else -> null
+                }
+            }
+            onCompiled { name, bytecode -> compiled[name] = bytecode }
+        }
+
+        var captured = 0
+        quickJs(moduleLoader = loader) {
+            function("capture") { captured = (it.first() as Number).toInt() }
+            evaluate<Any?>(
+                "import { result } from 'middle'; capture(result);",
+                asModule = true,
+            )
+        }
+
+        assertEquals(42, captured)
+        assertEquals(setOf("middle"), compiled.keys)
+    }
+
+    @Test
+    fun resolveModuleGraphReturnsStaticGraphWithoutEvaluation() = runTest {
+        val sources = mapOf(
+            "middle" to """
+                import { value } from "leaf";
+                moduleExecuted();
+                export const result = value * 2;
+            """.trimIndent(),
+            "leaf" to "export const value = 21;",
+            "dynamic" to "export const value = 100;",
+        )
+        var executions = 0
+        val loaded = mutableListOf<String>()
+        val loader = moduleLoader {
+            load { name ->
+                loaded += name
+                sources[name]?.let(ModuleContent::Source)
+            }
+        }
+
+        quickJs(moduleLoader = loader) {
+            function("moduleExecuted") { executions++ }
+            val entry = compile(
+                code = """
+                    import { result } from "middle";
+                    export { result };
+                    export async function later() {
+                        return (await import("dynamic")).value;
+                    }
+                """.trimIndent(),
+                filename = "entry",
+                asModule = true,
+            )
+
+            loaded.clear()
+            val resolved = resolveModuleGraph(entry)
+
+            assertEquals(setOf("entry", "middle", "leaf"), resolved)
+            assertEquals(listOf("middle", "leaf"), loaded)
+            assertEquals(0, executions)
+            assertFalse("dynamic" in resolved)
+        }
+    }
+
+    @Test
+    fun graphResolutionCanPopulateCacheForLaterEvaluation() = runTest {
+        val sources = mapOf(
+            "parent" to "import { value } from 'leaf'; export { value };",
+            "leaf" to "export const value = 42;",
+        )
+        val producer = moduleLoader {
+            load { name -> sources[name]?.let(ModuleContent::Source) }
+        }
+        val entryBytecode = quickJs(moduleLoader = producer) {
+            compile(
+                "import { value } from 'parent'; capture(value);",
+                filename = "entry",
+                asModule = true,
+            )
+        }
+
+        val cache = linkedMapOf<String, ByteArray>()
+        var sourceLoads = 0
+        val cachingLoader = moduleLoader {
+            load { name ->
+                cache[name]?.let(ModuleContent::Bytecode)
+                    ?: sources[name]?.let {
+                        sourceLoads++
+                        ModuleContent.Source(it)
+                    }
+            }
+            onCompiled { name, bytecode -> cache[name] = bytecode }
+        }
+
+        var captured = 0
+        quickJs(moduleLoader = cachingLoader) {
+            function("capture") { captured = (it.first() as Number).toInt() }
+
+            assertEquals(
+                setOf("entry", "parent", "leaf"),
+                resolveModuleGraph(entryBytecode),
+            )
+            assertEquals(2, sourceLoads)
+            assertEquals(setOf("parent", "leaf"), cache.keys)
+
+            evaluate<Any?>(entryBytecode)
+        }
+
+        assertEquals(42, captured)
+        assertEquals(2, sourceLoads)
+    }
+
+    @Test
+    fun repeatedGraphResolutionReturnsTheCompleteGraph() = runTest {
+        val sources = mapOf(
+            "parent" to "import { value } from 'leaf'; export { value };",
+            "leaf" to "export const value = 42;",
+        )
+        val loader = moduleLoader {
+            load { name -> sources[name]?.let(ModuleContent::Source) }
+        }
+
+        quickJs(moduleLoader = loader) {
+            val entry = compile(
+                "import { value } from 'parent'; export { value };",
+                filename = "entry",
+                asModule = true,
+            )
+
+            val first = resolveModuleGraph(entry)
+            val second = resolveModuleGraph(entry)
+
+            assertEquals(setOf("entry", "parent", "leaf"), first)
+            assertEquals(first, second)
+        }
+    }
+
+    @Test
+    fun successfullyCompiledSiblingIsReportedBeforeGraphFailure() = runTest {
+        val completeLoader = moduleLoader {
+            load { name ->
+                when (name) {
+                    "first" -> ModuleContent.Source("export const first = 20;")
+                    "missing" -> ModuleContent.Source("export const second = 22;")
+                    else -> null
+                }
+            }
+        }
+        val entryBytecode = quickJs(moduleLoader = completeLoader) {
+            compile(
+                code = """
+                    import { first } from "first";
+                    import { second } from "missing";
+                    export const result = first + second;
+                """.trimIndent(),
+                filename = "entry",
+                asModule = true,
+            )
+        }
+
+        val compiledBeforeFailure = linkedMapOf<String, ByteArray>()
+        val incompleteLoader = moduleLoader {
+            load { name ->
+                if (name == "first") {
+                    ModuleContent.Source("export const first = 20;")
+                } else {
+                    null
+                }
+            }
+            onCompiled { name, bytecode -> compiledBeforeFailure[name] = bytecode }
+        }
+
+        quickJs(moduleLoader = incompleteLoader) {
+            assertFailsWith<QuickJsException> {
+                resolveModuleGraph(entryBytecode)
+            }
+        }
+
+        assertEquals(setOf("first"), compiledBeforeFailure.keys)
+        assertTrue(compiledBeforeFailure.getValue("first").isNotEmpty())
+    }
+
+    @Test
+    fun dynamicImportUsesTheRuntimeLoaderAndReportsCompiledBytecode() = runTest {
+        val compiled = linkedMapOf<String, ByteArray>()
+        val loader = moduleLoader {
+            load { name ->
+                when (name) {
+                    "base" -> ModuleContent.Source("export const value = 20;")
+                    "dynamic" -> ModuleContent.Source("export const value = 22;")
+                    else -> null
+                }
+            }
+            onCompiled { name, bytecode -> compiled[name] = bytecode }
+        }
+
+        var captured = 0
+        quickJs(moduleLoader = loader) {
+            function("capture") { captured = (it.first() as Number).toInt() }
+            evaluate<Any?>(
+                code = """
+                    import { value } from "base";
+                    const loaded = await import("dynamic");
+                    capture(value + loaded.value);
+                """.trimIndent(),
+                filename = "entry",
+                asModule = true,
+            )
+        }
+
+        assertEquals(42, captured)
+        assertEquals(setOf("base", "dynamic"), compiled.keys)
+    }
+
+    @Test
+    fun circularDependenciesAreLoadedAndCompiledOnce() = runTest {
+        val loadCounts = mutableMapOf<String, Int>()
+        val compileCounts = mutableMapOf<String, Int>()
+        val loader = moduleLoader {
+            load { name ->
+                loadCounts[name] = loadCounts.getOrElse(name) { 0 } + 1
+                when (name) {
+                    "cycle-a" -> ModuleContent.Source(
+                        """
+                            import { fromB } from "cycle-b";
+                            export function fromA() { return 20; }
+                            export function total() { return fromA() + fromB(); }
+                        """.trimIndent()
+                    )
+                    "cycle-b" -> ModuleContent.Source(
+                        """
+                            import { fromA } from "cycle-a";
+                            export function fromB() { return fromA() + 2; }
+                        """.trimIndent()
+                    )
+                    else -> null
+                }
+            }
+            onCompiled { name, _ ->
+                compileCounts[name] = compileCounts.getOrElse(name) { 0 } + 1
+            }
+        }
+
+        var captured = 0
+        quickJs(moduleLoader = loader) {
+            function("capture") { captured = (it.first() as Number).toInt() }
+            evaluate<Any?>(
+                "import { total } from 'cycle-a'; capture(total());",
+                asModule = true,
+            )
+        }
+
+        assertEquals(42, captured)
+        assertEquals(mapOf("cycle-a" to 1, "cycle-b" to 1), loadCounts)
+        assertEquals(mapOf("cycle-a" to 1, "cycle-b" to 1), compileCounts)
+    }
+
+    @Test
+    fun missingModuleFailsWithItsNormalizedName() = runTest {
+        val loader = moduleLoader { load { null } }
+
+        val failure = quickJs(moduleLoader = loader) {
+            assertFailsWith<QuickJsException> {
+                evaluate<Any?>(
+                    "import 'missing';",
+                    filename = "entry",
+                    asModule = true,
+                )
+            }
+        }
+
+        assertContains(failure.message.orEmpty(), "missing")
+    }
+
+    @Test
+    fun corruptAndMismatchedBytecodeAreRejected() = runTest {
+        val actualModule = quickJs {
+            compile(
+                "export const value = 42;",
+                filename = "actual",
+                asModule = true,
+            )
+        }
+
+        val corruptLoader = moduleLoader {
+            load { ModuleContent.Bytecode(byteArrayOf(0, 1, 2, 3)) }
+        }
+        quickJs(moduleLoader = corruptLoader) {
+            assertFailsWith<QuickJsException> {
+                evaluate<Any?>("import 'corrupt';", asModule = true)
+            }
+        }
+
+        val mismatchedLoader = moduleLoader {
+            load { ModuleContent.Bytecode(actualModule) }
+        }
+        val mismatch = quickJs(moduleLoader = mismatchedLoader) {
+            assertFailsWith<QuickJsException> {
+                evaluate<Any?>("import 'expected';", asModule = true)
+            }
+        }
+        assertContains(mismatch.message.orEmpty(), "expected")
+    }
+
+    @Test
+    fun invalidatedSourceIsRecompiledAndThenReusableAsBytecode() = runTest {
+        val versionOne = quickJs {
+            compile(
+                "export const value = 21;",
+                filename = "value",
+                asModule = true,
+            )
+        }
+        val refreshed = linkedMapOf<String, ByteArray>()
+        val sourceLoader = moduleLoader {
+            load { name ->
+                if (name == "value") {
+                    ModuleContent.Source("export const value = 42;")
+                } else {
+                    null
+                }
+            }
+            onCompiled { name, bytecode -> refreshed[name] = bytecode }
+        }
+
+        var sourceResult = 0
+        quickJs(moduleLoader = sourceLoader) {
+            function("capture") { sourceResult = (it.first() as Number).toInt() }
+            evaluate<Any?>(
+                "import { value } from 'value'; capture(value);",
+                asModule = true,
+            )
+        }
+
+        val versionTwo = refreshed.getValue("value")
+        assertEquals(42, sourceResult)
+        assertNotEquals(versionOne.toList(), versionTwo.toList())
+
+        var bytecodeResult = 0
+        var recompilations = 0
+        val bytecodeLoader = moduleLoader {
+            load { name ->
+                if (name == "value") ModuleContent.Bytecode(versionTwo) else null
+            }
+            onCompiled { _, _ -> recompilations++ }
+        }
+        quickJs(moduleLoader = bytecodeLoader) {
+            function("capture") { bytecodeResult = (it.first() as Number).toInt() }
+            evaluate<Any?>(
+                "import { value } from 'value'; capture(value);",
+                asModule = true,
+            )
+        }
+
+        assertEquals(42, bytecodeResult)
+        assertEquals(0, recompilations)
+    }
+
+    @Test
+    fun relativeImportsArePassedToLoaderAsNormalizedNames() = runTest {
+        val requested = mutableListOf<String>()
+        val loader = moduleLoader {
+            load { name ->
+                requested += name
+                if (name == "app/value.js") {
+                    ModuleContent.Source("export const value = 42;")
+                } else {
+                    null
+                }
+            }
+        }
+
+        var captured = 0
+        quickJs(moduleLoader = loader) {
+            function("capture") { captured = (it.first() as Number).toInt() }
+            evaluate<Any?>(
+                "import { value } from './value.js'; capture(value);",
+                filename = "app/entry.js",
+                asModule = true,
+            )
+        }
+
+        assertEquals(42, captured)
+        assertEquals(listOf("app/value.js"), requested)
+    }
+
+    @Test
+    fun loaderAndCompilationCallbackExceptionsFailTheOperation() = runTest {
+        val loadFailure = moduleLoader {
+            load { throw IllegalStateException("load failed") }
+        }
+        val loadError = quickJs(moduleLoader = loadFailure) {
+            assertFails {
+                evaluate<Any?>("import 'dependency';", asModule = true)
+            }
+        }
+        assertContains(loadError.message.orEmpty(), "load failed")
+
+        val compileError = quickJs(moduleLoader = loadFailure) {
+            assertFails {
+                compile(
+                    "import 'dependency';",
+                    filename = "compile-entry",
+                    asModule = true,
+                )
+            }
+        }
+        assertContains(compileError.message.orEmpty(), "load failed")
+
+        val callbackFailure = moduleLoader {
+            load { ModuleContent.Source("export const value = 42;") }
+            onCompiled { _, _ -> throw IllegalStateException("persistence handoff failed") }
+        }
+        val callbackError = quickJs(moduleLoader = callbackFailure) {
+            assertFails {
+                evaluate<Any?>("import 'dependency';", asModule = true)
+            }
+        }
+        assertContains(callbackError.message.orEmpty(), "persistence handoff failed")
+    }
+
+    @Test
+    fun invalidSourceCanBeCorrectedBeforeSuccessfulResolution() = runTest {
+        var source = "export const value = ;"
+        val loader = moduleLoader {
+            load { name ->
+                if (name == "recoverable") ModuleContent.Source(source) else null
+            }
+        }
+
+        var captured = 0
+        quickJs(moduleLoader = loader) {
+            function("capture") { captured = (it.first() as Number).toInt() }
+            assertFailsWith<QuickJsException> {
+                evaluate<Any?>(
+                    "import { value } from 'recoverable'; capture(value);",
+                    filename = "failed-entry",
+                    asModule = true,
+                )
+            }
+
+            source = "export const value = 42;"
+            evaluate<Any?>(
+                "import { value } from 'recoverable'; capture(value);",
+                filename = "recovered-entry",
+                asModule = true,
+            )
+        }
+
+        assertEquals(42, captured)
+    }
+
+    @Test
+    fun loadedModuleKeepsItsInstanceUntilTheRuntimeIsRecreated() = runTest {
+        var source = "export const value = 21;"
+        var loads = 0
+        val loader = moduleLoader {
+            load { name ->
+                if (name == "stable") {
+                    loads++
+                    ModuleContent.Source(source)
+                } else {
+                    null
+                }
+            }
+        }
+
+        val results = mutableListOf<Int>()
+        quickJs(moduleLoader = loader) {
+            function("capture") {
+                results += (it.first() as Number).toInt()
+            }
+            evaluate<Any?>(
+                "import { value } from 'stable'; capture(value);",
+                filename = "first-entry",
+                asModule = true,
+            )
+
+            source = "export const value = 42;"
+            evaluate<Any?>(
+                "import { value } from 'stable'; capture(value);",
+                filename = "second-entry",
+                asModule = true,
+            )
+        }
+
+        assertEquals(listOf(21, 21), results)
+        assertEquals(1, loads)
+
+        quickJs(moduleLoader = loader) {
+            function("capture") {
+                results += (it.first() as Number).toInt()
+            }
+            evaluate<Any?>(
+                "import { value } from 'stable'; capture(value);",
+                filename = "new-runtime-entry",
+                asModule = true,
+            )
+        }
+
+        assertEquals(listOf(21, 21, 42), results)
+        assertEquals(2, loads)
+    }
+}

--- a/quickjs/src/commonTest/kotlin/com/dokar/quickjs/test/ModulesTest.kt
+++ b/quickjs/src/commonTest/kotlin/com/dokar/quickjs/test/ModulesTest.kt
@@ -9,6 +9,7 @@ import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
 
+@Suppress("DEPRECATION")
 class ModulesTest {
     @Test
     fun codeAsModule() = runTest {

--- a/quickjs/src/jniMain/kotlin/com/dokar/quickjs/QuickJs.jni.kt
+++ b/quickjs/src/jniMain/kotlin/com/dokar/quickjs/QuickJs.jni.kt
@@ -23,11 +23,11 @@ import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.ensureActive
-import kotlinx.coroutines.job
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.job
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -145,6 +145,7 @@ suspend fun <T> QuickJs.evaluate(
 @OptIn(ExperimentalUnsignedTypes::class, ExperimentalAtomicApi::class)
 actual class QuickJs private constructor(
     private val jobDispatcher: CoroutineDispatcher,
+    private val moduleLoader: ModuleLoader?,
 ) : Closeable {
     // Native pointers
     private var globals: Long = 0
@@ -156,6 +157,7 @@ actual class QuickJs private constructor(
     private val globalFunctions = mutableMapOf<String, Binding>()
 
     private val modules = mutableListOf<ByteArray>()
+    private var resolvingModuleNames: LinkedHashSet<String>? = null
 
     private var evalException: Throwable? = null
     private var currentEvaluationSession: EvaluationSession? = null
@@ -230,13 +232,20 @@ actual class QuickJs private constructor(
             runtime = newRuntime()
             interruptState = installInterrupt(runtime)
             context = newContext(runtime)
+        } catch (error: QuickJsException) {
+            close()
+            throw error
+        }
+        try {
+            // Module-loader installation performs JNI lookups that may throw
+            // exceptions outside the QuickJsException hierarchy.
             globals = initGlobals(
                 runtime,
                 arrayOf(Unit::class.java, UByteArray::class.java)
             )
-        } catch (e: QuickJsException) {
+        } catch (error: Throwable) {
             close()
-            throw e
+            throw error
         }
     }
 
@@ -313,6 +322,23 @@ actual class QuickJs private constructor(
         return withJsLockSync {
             ensureNotClosed()
             return compile(context, globals, filename, code, asModule)
+        }
+    }
+
+    @Throws(QuickJsException::class)
+    actual fun resolveModuleGraph(entryBytecode: ByteArray): Set<String> = withJsLockSync {
+        ensureNotClosed()
+        val names = linkedSetOf<String>()
+        resolvingModuleNames = names
+        try {
+            names += resolveModuleGraphBytecode(
+                runtime = runtime,
+                globals = globals,
+                bytecode = entryBytecode,
+            )
+            names
+        } finally {
+            resolvingModuleNames = null
         }
     }
 
@@ -579,6 +605,30 @@ actual class QuickJs private constructor(
         }
     }
 
+    /** Loads module content synchronously for the JNI bridge. */
+    @Suppress("unused")
+    private fun loadModule(name: String): Any? {
+        resolvingModuleNames?.add(name)
+        return moduleLoader?.load(name)
+    }
+
+    /** Returns source when [content] represents a source module. */
+    @Suppress("unused")
+    private fun getModuleSource(content: Any): String? =
+        (content as? ModuleContent.Source)?.code
+
+    /** Returns bytecode when [content] represents a compiled module. */
+    @Suppress("unused")
+    private fun getModuleBytecode(content: Any): ByteArray? =
+        (content as? ModuleContent.Bytecode)?.bytes
+
+    /** Delivers source-compiled bytecode to the runtime's loader. */
+    @Suppress("unused")
+    private fun onModuleCompiled(name: String, bytecode: ByteArray) {
+        moduleLoader?.onCompiled(name, bytecode)
+    }
+
+    /** Loads queued modules using the legacy addModule behavior. */
     private suspend fun loadModules(session: EvaluationSession) = jsMutex.withLock {
         ensureNotClosed()
         withEvaluationSession(session) {
@@ -868,6 +918,13 @@ actual class QuickJs private constructor(
     ): ByteArray
 
     @Throws(QuickJsException::class)
+    private external fun resolveModuleGraphBytecode(
+        runtime: Long,
+        globals: Long,
+        bytecode: ByteArray,
+    ): String
+
+    @Throws(QuickJsException::class)
     private external fun evaluate(
         context: Long,
         globals: Long,
@@ -941,6 +998,16 @@ actual class QuickJs private constructor(
             jobDispatcher: CoroutineDispatcher,
         ): QuickJs = QuickJs(
             jobDispatcher = jobDispatcher,
+            moduleLoader = null,
+        )
+
+        @Throws(QuickJsException::class)
+        actual fun create(
+            jobDispatcher: CoroutineDispatcher,
+            moduleLoader: ModuleLoader,
+        ): QuickJs = QuickJs(
+            jobDispatcher = jobDispatcher,
+            moduleLoader = moduleLoader,
         )
     }
 }

--- a/quickjs/src/jniMain/resources/META-INF/native-image/com.dokar.quickjs/quickjs/reachability-metadata.json
+++ b/quickjs/src/jniMain/resources/META-INF/native-image/com.dokar.quickjs/quickjs/reachability-metadata.json
@@ -382,6 +382,31 @@
           ]
         },
         {
+          "name": "loadModule",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "getModuleSource",
+          "parameterTypes": [
+            "java.lang.Object"
+          ]
+        },
+        {
+          "name": "getModuleBytecode",
+          "parameterTypes": [
+            "java.lang.Object"
+          ]
+        },
+        {
+          "name": "onModuleCompiled",
+          "parameterTypes": [
+            "java.lang.String",
+            "byte[]"
+          ]
+        },
+        {
           "name": "setEvalException",
           "parameterTypes": [
             "java.lang.Throwable"

--- a/quickjs/src/nativeMain/kotlin/com/dokar/quickjs/QuickJs.native.kt
+++ b/quickjs/src/nativeMain/kotlin/com/dokar/quickjs/QuickJs.native.kt
@@ -15,6 +15,8 @@ import com.dokar.quickjs.bridge.executePendingJob
 import com.dokar.quickjs.bridge.invokeJsFunction
 import com.dokar.quickjs.bridge.ktMemoryUsage
 import com.dokar.quickjs.bridge.objectHandleToStableRef
+import com.dokar.quickjs.bridge.resolveModuleGraph
+import com.dokar.quickjs.bridge.setModuleLoader
 import com.dokar.quickjs.bridge.setPromiseRejectionHandler
 import com.dokar.quickjs.converter.TypeConverter
 import com.dokar.quickjs.converter.TypeConverters
@@ -36,11 +38,11 @@ import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.ensureActive
-import kotlinx.coroutines.job
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.job
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -63,17 +65,18 @@ import quickjs.qjs_interrupt_install
 import quickjs.qjs_interrupt_request
 import quickjs.qjs_interrupt_reset
 import quickjs.quickjs_version
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.coroutines.AbstractCoroutineContextElement
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.coroutines.coroutineContext
-import kotlin.concurrent.atomics.AtomicBoolean
-import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.reflect.typeOf
 
 @OptIn(ExperimentalForeignApi::class, ExperimentalAtomicApi::class)
 actual class QuickJs private constructor(
-    private val jobDispatcher: CoroutineDispatcher
+    private val jobDispatcher: CoroutineDispatcher,
+    private val moduleLoader: ModuleLoader?,
 ) {
     private val runtime: CPointer<JSRuntime> = JS_NewRuntime()
         ?: qjsError("Failed to create js runtime.")
@@ -101,6 +104,7 @@ actual class QuickJs private constructor(
     private val managedJsValues = mutableListOf<CValue<JSValue>>()
 
     private val modules = mutableListOf<ByteArray>()
+    private var resolvingModuleNames: LinkedHashSet<String>? = null
 
     private val jobsMutex = Mutex()
     private val asyncJobs = mutableListOf<AsyncJob>()
@@ -168,6 +172,9 @@ actual class QuickJs private constructor(
     init {
         interruptState = qjs_interrupt_install(runtime)
         setPromiseRejectionHandler(ref, runtime)
+        if (moduleLoader != null) {
+            setModuleLoader(ref, runtime)
+        }
     }
 
     actual fun addTypeConverters(vararg converters: TypeConverter<*, *>) {
@@ -250,6 +257,22 @@ actual class QuickJs private constructor(
         return withJsLockSync {
             ensureNotClosed()
             return context.compile(code = code, filename = filename, asModule = asModule)
+        }
+    }
+
+    @Throws(QuickJsException::class)
+    actual fun resolveModuleGraph(entryBytecode: ByteArray): Set<String> = withJsLockSync {
+        ensureNotClosed()
+        val graphContext = JS_NewContext(runtime)
+            ?: qjsError("Failed to create module graph context.")
+        val names = linkedSetOf<String>()
+        resolvingModuleNames = names
+        try {
+            names += graphContext.resolveModuleGraph(entryBytecode)
+            names
+        } finally {
+            resolvingModuleNames = null
+            JS_FreeContext(graphContext)
         }
     }
 
@@ -548,6 +571,18 @@ actual class QuickJs private constructor(
         }
     }
 
+    /** Loads content from the runtime-scoped module loader. */
+    internal fun loadModule(name: String): ModuleContent? {
+        resolvingModuleNames?.add(name)
+        return moduleLoader?.load(name)
+    }
+
+    /** Delivers source-compiled bytecode to the runtime-scoped module loader. */
+    internal fun onModuleCompiled(name: String, bytecode: ByteArray) {
+        moduleLoader?.onCompiled(name, bytecode)
+    }
+
+    /** Loads queued modules using the legacy addModule behavior. */
     private suspend fun loadModules(session: EvaluationSession) = jsMutex.withLock {
         ensureNotClosed()
         withEvaluationSession(session) {
@@ -693,7 +728,21 @@ actual class QuickJs private constructor(
     actual companion object {
         @Throws(QuickJsException::class)
         actual fun create(jobDispatcher: CoroutineDispatcher): QuickJs {
-            return QuickJs(jobDispatcher = jobDispatcher)
+            return QuickJs(
+                jobDispatcher = jobDispatcher,
+                moduleLoader = null,
+            )
+        }
+
+        @Throws(QuickJsException::class)
+        actual fun create(
+            jobDispatcher: CoroutineDispatcher,
+            moduleLoader: ModuleLoader,
+        ): QuickJs {
+            return QuickJs(
+                jobDispatcher = jobDispatcher,
+                moduleLoader = moduleLoader,
+            )
         }
     }
 }

--- a/quickjs/src/nativeMain/kotlin/com/dokar/quickjs/bridge/evaluate.kt
+++ b/quickjs/src/nativeMain/kotlin/com/dokar/quickjs/bridge/evaluate.kt
@@ -1,5 +1,6 @@
 package com.dokar.quickjs.bridge
 
+import cnames.structs.JSModuleDef
 import com.dokar.quickjs.QuickJsException
 import com.dokar.quickjs.qjsError
 import kotlinx.cinterop.CPointer
@@ -9,25 +10,37 @@ import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.UByteVar
 import kotlinx.cinterop.cstr
 import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.reinterpret
 import kotlinx.cinterop.toCValues
 import quickjs.JSContext
 import quickjs.JSValue
+import quickjs.JS_AtomToString
 import quickjs.JS_EVAL_FLAG_ASYNC
 import quickjs.JS_EVAL_FLAG_COMPILE_ONLY
 import quickjs.JS_EVAL_TYPE_MODULE
 import quickjs.JS_Eval
 import quickjs.JS_EvalFunction
+import quickjs.JS_FreeAtom
 import quickjs.JS_FreeValue
 import quickjs.JS_GetException
+import quickjs.JS_GetModuleName
 import quickjs.JS_GetRuntime
 import quickjs.JS_READ_OBJ_BYTECODE
+import quickjs.JS_READ_OBJ_REFERENCE
 import quickjs.JS_ReadObject
+import quickjs.JS_ResolveModule
 import quickjs.JS_TAG_FUNCTION_BYTECODE
 import quickjs.JS_TAG_MODULE
 import quickjs.JS_TAG_NULL
 import quickjs.JS_TAG_UNINITIALIZED
 import quickjs.JS_UpdateStackTop
 import quickjs.JsValueGetNormTag
+import quickjs.JsValueGetPtr
+
+@OptIn(ExperimentalForeignApi::class)
+@Suppress("UNCHECKED_CAST")
+private fun ByteArray.toBytecodeBuffer(): CValues<UByteVar> =
+    toCValues() as CValues<UByteVar>
 
 @OptIn(ExperimentalForeignApi::class)
 @Throws(QuickJsException::class)
@@ -57,6 +70,45 @@ internal fun CPointer<JSContext>.compile(
         }
         toKtValue(context = this@compile)
     } as? ByteArray ?: qjsError("Failed to read bytecode.")
+}
+
+/**
+ * Resolves an ES module bytecode graph without evaluating it.
+ *
+ * @return The module name stored in the entry bytecode.
+ */
+@OptIn(ExperimentalForeignApi::class)
+@Throws(QuickJsException::class)
+internal fun CPointer<JSContext>.resolveModuleGraph(bytecode: ByteArray): String = memScoped {
+    val buffer = bytecode.toBytecodeBuffer()
+    JS_UpdateStackTop(JS_GetRuntime(this@resolveModuleGraph))
+    val entry = JS_ReadObject(
+        ctx = this@resolveModuleGraph,
+        buf = buffer,
+        buf_len = buffer.size.toULong(),
+        flags = JS_READ_OBJ_BYTECODE or JS_READ_OBJ_REFERENCE,
+    )
+    entry.use(this@resolveModuleGraph) {
+        checkContextException(this@resolveModuleGraph)
+        if (JsValueGetNormTag(this) != JS_TAG_MODULE) {
+            qjsError("Bytecode is not an ES module.")
+        }
+        val moduleDefinition = JsValueGetPtr(this)?.reinterpret<JSModuleDef>()
+            ?: qjsError("Cannot read the ES module definition.")
+        val nameAtom = JS_GetModuleName(this@resolveModuleGraph, moduleDefinition)
+        val nameValue = JS_AtomToString(this@resolveModuleGraph, nameAtom)
+        JS_FreeAtom(this@resolveModuleGraph, nameAtom)
+        val name = nameValue.use(this@resolveModuleGraph) {
+            checkContextException(this@resolveModuleGraph)
+            toKtValue(this@resolveModuleGraph) as? String
+                ?: qjsError("Cannot read the ES module name.")
+        }
+        if (JS_ResolveModule(this@resolveModuleGraph, this) < 0) {
+            checkContextException(this@resolveModuleGraph)
+            qjsError("Cannot resolve ES module entry bytecode.")
+        }
+        name
+    }
 }
 
 @OptIn(ExperimentalForeignApi::class)
@@ -90,15 +142,26 @@ internal fun CPointer<JSContext>.evaluate(
 ): JsPromise = memScoped {
     val context = this@evaluate
 
-    @Suppress("UNCHECKED_CAST")
-    val buffer = bytecode.toCValues() as CValues<UByteVar>
+    val buffer = bytecode.toBytecodeBuffer()
     JS_UpdateStackTop(JS_GetRuntime(context))
     val jsValue = JS_ReadObject(
         ctx = context,
         buf = buffer,
         buf_len = buffer.size.toULong(),
-        flags = JS_READ_OBJ_BYTECODE,
+        flags = JS_READ_OBJ_BYTECODE or JS_READ_OBJ_REFERENCE,
     )
+    try {
+        checkContextException(context)
+        if (JsValueGetNormTag(jsValue) == JS_TAG_MODULE &&
+            JS_ResolveModule(context, jsValue) < 0
+        ) {
+            checkContextException(context)
+            qjsError("Cannot resolve module bytecode.")
+        }
+    } catch (error: Throwable) {
+        JS_FreeValue(context, jsValue)
+        throw error
+    }
     val result = JS_EvalFunction(
         ctx = context,
         fun_obj = jsValue,

--- a/quickjs/src/nativeMain/kotlin/com/dokar/quickjs/bridge/moduleLoader.kt
+++ b/quickjs/src/nativeMain/kotlin/com/dokar/quickjs/bridge/moduleLoader.kt
@@ -1,0 +1,161 @@
+package com.dokar.quickjs.bridge
+
+import cnames.structs.JSModuleDef
+import com.dokar.quickjs.ModuleContent
+import com.dokar.quickjs.QuickJs
+import com.dokar.quickjs.qjsError
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.COpaquePointer
+import kotlinx.cinterop.CPointer
+import kotlinx.cinterop.CValues
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.StableRef
+import kotlinx.cinterop.UByteVar
+import kotlinx.cinterop.asStableRef
+import kotlinx.cinterop.cstr
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.staticCFunction
+import kotlinx.cinterop.toCValues
+import kotlinx.cinterop.toKStringFromUtf8
+import quickjs.JSContext
+import quickjs.JSRuntime
+import quickjs.JS_AtomToString
+import quickjs.JS_EVAL_FLAG_COMPILE_ONLY
+import quickjs.JS_EVAL_TYPE_MODULE
+import quickjs.JS_Eval
+import quickjs.JS_FreeAtom
+import quickjs.JS_GetModuleName
+import quickjs.JS_IsException
+import quickjs.JS_READ_OBJ_BYTECODE
+import quickjs.JS_READ_OBJ_REFERENCE
+import quickjs.JS_ReadObject
+import quickjs.JS_SetModuleLoaderFunc
+import quickjs.JS_TAG_MODULE
+import quickjs.JS_Throw
+import quickjs.JsValueGetNormTag
+import quickjs.JsValueGetPtr
+
+/** Compiles source returned by the runtime-scoped module loader. */
+@OptIn(ExperimentalForeignApi::class)
+private fun compileSourceModule(
+    context: CPointer<JSContext>,
+    quickJs: QuickJs,
+    name: String,
+    source: String,
+): CPointer<JSModuleDef>? {
+    val sourceString = source.cstr
+    val compiled = JS_Eval(
+        ctx = context,
+        input = sourceString,
+        input_len = (sourceString.size - 1).toULong(),
+        filename = name.cstr,
+        eval_flags = JS_EVAL_TYPE_MODULE or JS_EVAL_FLAG_COMPILE_ONLY,
+    )
+    return compiled.use(context) {
+        // Preserve the syntax exception already stored on the context.
+        if (JS_IsException(this) == 1) return@use null
+        if (JsValueGetNormTag(this) != JS_TAG_MODULE) {
+            qjsError("Module loader returned unsupported source for '$name'.")
+        }
+        val bytecode = toKtValue(context) as? ByteArray
+            ?: qjsError("Cannot write bytecode for module '$name'.")
+        quickJs.onModuleCompiled(name, bytecode)
+        JsValueGetPtr(this)?.reinterpret<JSModuleDef>()
+            ?: qjsError("Cannot read the ES module definition for '$name'.")
+    }
+}
+
+/** Reads cached bytecode and verifies that it belongs to the requested name. */
+@OptIn(ExperimentalForeignApi::class)
+@Suppress("UNCHECKED_CAST")
+private fun readBytecodeModule(
+    context: CPointer<JSContext>,
+    name: String,
+    bytecode: ByteArray,
+): CPointer<JSModuleDef>? = memScoped {
+    val buffer = bytecode.toCValues() as CValues<UByteVar>
+    val module = JS_ReadObject(
+        ctx = context,
+        buf = buffer,
+        buf_len = buffer.size.toULong(),
+        flags = JS_READ_OBJ_BYTECODE or JS_READ_OBJ_REFERENCE,
+    )
+    module.use(context) {
+        // Preserve the bytecode exception already stored on the context.
+        if (JS_IsException(this) == 1) return@use null
+        if (JsValueGetNormTag(this) != JS_TAG_MODULE) {
+            qjsError("Bytecode for '$name' is not an ES module.")
+        }
+        val definition = JsValueGetPtr(this)?.reinterpret<JSModuleDef>()
+            ?: qjsError("Cannot read the ES module definition for '$name'.")
+        val bytecodeName = readModuleName(context, definition)
+        if (bytecodeName != name) {
+            qjsError("Module bytecode name '$bytecodeName' does not match '$name'.")
+        }
+        definition
+    }
+}
+
+/** Reads the normalized name retained by a compiled module definition. */
+@OptIn(ExperimentalForeignApi::class)
+private fun readModuleName(
+    context: CPointer<JSContext>,
+    module: CPointer<JSModuleDef>,
+): String {
+    val nameAtom = JS_GetModuleName(context, module)
+    val nameValue = JS_AtomToString(context, nameAtom)
+    JS_FreeAtom(context, nameAtom)
+    return nameValue.use(context) {
+        checkContextException(context)
+        toKtValue(context) as? String
+            ?: qjsError("Cannot read the ES module name.")
+    }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun loadModule(
+  context: CPointer<JSContext>?,
+  moduleName: CPointer<ByteVar>?,
+  opaque: COpaquePointer?,
+): CPointer<JSModuleDef>? {
+  val jsContext = context ?: return null
+  val quickJs = opaque?.asStableRef<QuickJs>()?.get()
+  return try {
+    val name = moduleName?.toKStringFromUtf8()
+      ?: qjsError("Missing ES module name.")
+    val owner = quickJs ?: qjsError("Missing QuickJs module loader state.")
+    when (val content = owner.loadModule(name)
+      ?: qjsError("could not load module '$name'")) {
+      is ModuleContent.Source -> compileSourceModule(
+        context = jsContext,
+        quickJs = owner,
+        name = name,
+        source = content.code,
+      )
+
+      is ModuleContent.Bytecode -> readBytecodeModule(
+        context = jsContext,
+        name = name,
+        bytecode = content.bytes,
+      )
+    }
+  } catch (error: Throwable) {
+    JS_Throw(jsContext, ktErrorToJsError(jsContext, error))
+    null
+  }
+}
+
+/** Installs the runtime-scoped host module loader. */
+@OptIn(ExperimentalForeignApi::class)
+internal fun setModuleLoader(
+    quickJs: StableRef<QuickJs>,
+    runtime: CPointer<JSRuntime>,
+) {
+    JS_SetModuleLoaderFunc(
+        rt = runtime,
+        module_normalize = null,
+        module_loader = staticCFunction(::loadModule),
+        opaque = quickJs.asCPointer(),
+    )
+}


### PR DESCRIPTION
## Background

QuickJS supports ES modules, but the previous API only offered a legacy pre-evaluation addModule queue. Callers could not lazily choose source or cached bytecode when QuickJS resolved a dependency, and module bytecode containing imports could fail at the native boundary.

This PR adds a runtime-scoped module loader for JNI and Kotlin/Native while leaving cache ownership, invalidation, and persistence entirely to callers.

## API

- ModuleContent.Source and ModuleContent.Bytecode represent loader results.
- ModuleLoader.load(name) supplies source, compatible bytecode, or null.
- ModuleLoader.onCompiled(name, bytecode) receives source-compiled module bytecode immediately.
- quickJs and QuickJs.create have explicit overloads accepting a ModuleLoader.
- resolveModuleGraph(entryBytecode) returns the entry and statically reachable normalized module names without evaluation.

Existing creation overloads are unchanged. Both legacy addModule overloads retain their established queue behavior and are deprecated in favor of the loader.

## Behavior

- load is called lazily for static and dynamic imports.
- onCompiled may update an in-memory cache synchronously and enqueue slower persistence work.
- Loader callbacks run while QuickJS is resolving a module. They must return quickly and must not re-enter the same runtime; unhandled callback exceptions propagate unchanged.
- resolveModuleGraph uses a temporary context, so it does not evaluate top-level code or preload the main context.
- Source and bytecode modules can be mixed across nested and cyclic graphs. Bytecode is validated as a module and must retain the requested normalized name.
- Dynamic import uses the same loader during evaluation.
- Changing a loaded module requires a new runtime, preserving standard ESM identity and execute-once semantics.

QuickJS bytecode is version-specific. Cache keys, source hashes, persistence, retries, replacement, and eviction remain caller responsibilities.

## Tests

- Covers source, bytecode, and mixed graphs; arbitrary order; nested and cyclic dependencies; cache refresh; relative names; missing, corrupt, and mismatched modules; static and dynamic imports; top-level await; callback failures; and existing API compatibility.
- JVM and macOS ARM64 module and regression suites pass.
- Android and iOS Simulator ARM64 production and test sources compile.
- A MavenLocal artifact was verified in a downstream Kotlin Multiplatform project: all 17 Desktop tests and all iOS Simulator ARM64 tests pass, and Android device-test sources compile.

## Development note

The implementation, tests, and documentation in this PR were completed by OpenAI Codex (GPT-5.6-sol), with requirements confirmed and the result reviewed by the project user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `ModuleLoader` support for loading ES modules from source or reusable bytecode.
  * Added compilation callbacks for caching generated bytecode.
  * Added module dependency graph resolution without executing modules.
  * Added support for static and dynamic dependencies, caching, invalidation, cycles, and normalized paths.
  * Added runtime creation APIs that accept a module loader.

* **Documentation**
  * Expanded module-loading documentation and error guidance.
  * Deprecated legacy `addModule` APIs in favor of `ModuleLoader`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->