### PR TITLE
Report module load failures through ModuleLoader

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,10 @@ val loader = moduleLoader {
     onCompiled { name, bytecode ->
         bytecodeCache[name] = bytecode
     }
+    onLoadFailed { name ->
+        // Enqueue invalidation instead of performing blocking persistence here.
+        enqueueModuleBytecodeInvalidation(name)
+    }
 }
 
 quickJs(moduleLoader = loader) {
@@ -250,7 +254,7 @@ quickJs(moduleLoader = loader) {
 }
 ```
 
-`load()` runs when a static or dynamic import is resolved. `onCompiled()` receives bytecode for modules loaded from source. Both callbacks are synchronous, so keep them fast and do not re-enter the same `QuickJs` instance.
+`load()` runs when a static or dynamic import is resolved. `onCompiled()` receives bytecode for modules loaded from source. `onLoadFailed()` receives the normalized name when QuickJS cannot load a requested module, including handled dynamic import rejections. All callbacks are synchronous, so keep them fast, avoid blocking persistence, and do not re-enter the same `QuickJs` instance.
 
 Use `resolveModuleGraph()` to load and compile the static imports of cached entry bytecode without evaluating it:
 
@@ -261,7 +265,7 @@ quickJs(moduleLoader = loader) {
 }
 ```
 
-QuickJS bytecode is engine-version-specific and must use the same module name. Only load bytecode from a trusted source. Cache storage and invalidation are up to the application.
+QuickJS bytecode is engine-version-specific and must use the same module name. Only load bytecode from a trusted source. Cache storage and invalidation are up to the application; `onLoadFailed()` can enqueue invalidation of a failed cached module.
 
 When evaluating ES module code, no return values will be captured, you may need a function binding to receive the result.
 

--- a/quickjs/native/jni/module_loader.c
+++ b/quickjs/native/jni/module_loader.c
@@ -31,6 +31,23 @@ static int forward_java_exception(JNIEnv *env,
     return 1;
 }
 
+/** Notifies the host while the normalized name of a failed module is known. */
+static void notify_module_load_failed(JNIEnv *env,
+                                      Globals *globals,
+                                      JSContext *context,
+                                      jstring java_name,
+                                      const char *module_name) {
+    globals->module_load_failure_version++;
+    (*env)->CallVoidMethod(
+            env,
+            globals->module_loader_host,
+            globals->on_module_load_failed_method,
+            java_name);
+    forward_java_exception(
+            env, context,
+            "Module load failure callback failed for '%s'.", module_name);
+}
+
 /** Serializes a source-compiled module and immediately notifies its owner. */
 static int notify_module_compiled(JNIEnv *env,
                                   Globals *globals,
@@ -176,16 +193,16 @@ static JSModuleDef *load_module(JSContext *context, const char *module_name, voi
             globals->module_loader_host,
             globals->load_module_method,
             java_name);
+    JSModuleDef *definition = NULL;
+    uint64_t failure_version = globals->module_load_failure_version;
     if (forward_java_exception(
             env, context,
             "Kotlin module loader failed for '%s'.", module_name)) {
-        (*env)->DeleteLocalRef(env, java_name);
-        return NULL;
+        goto notify_failure;
     }
     if (content == NULL) {
-        (*env)->DeleteLocalRef(env, java_name);
         JS_ThrowReferenceError(context, "could not load module '%s'", module_name);
-        return NULL;
+        goto notify_failure;
     }
 
     jstring java_source = (jstring) (*env)->CallObjectMethod(
@@ -196,9 +213,7 @@ static JSModuleDef *load_module(JSContext *context, const char *module_name, voi
     if (forward_java_exception(
             env, context,
             "Cannot inspect module source for '%s'.", module_name)) {
-        (*env)->DeleteLocalRef(env, content);
-        (*env)->DeleteLocalRef(env, java_name);
-        return NULL;
+        goto notify_failure;
     }
 
     JSValue module = JS_UNDEFINED;
@@ -211,9 +226,7 @@ static JSModuleDef *load_module(JSContext *context, const char *module_name, voi
                 JS_ThrowInternalError(context, "Cannot read module source '%s'.", module_name);
             }
             (*env)->DeleteLocalRef(env, java_source);
-            (*env)->DeleteLocalRef(env, content);
-            (*env)->DeleteLocalRef(env, java_name);
-            return NULL;
+            goto notify_failure;
         }
         module = JS_Eval(
                 context,
@@ -238,15 +251,11 @@ static JSModuleDef *load_module(JSContext *context, const char *module_name, voi
         if (forward_java_exception(
                 env, context,
                 "Cannot inspect module bytecode for '%s'.", module_name)) {
-            (*env)->DeleteLocalRef(env, content);
-            (*env)->DeleteLocalRef(env, java_name);
-            return NULL;
+            goto notify_failure;
         }
         if (java_bytecode == NULL) {
-            (*env)->DeleteLocalRef(env, content);
-            (*env)->DeleteLocalRef(env, java_name);
             JS_ThrowTypeError(context, "Unsupported module content for '%s'.", module_name);
-            return NULL;
+            goto notify_failure;
         }
         module = read_module_bytecode(env, context, java_bytecode, module_name);
         (*env)->DeleteLocalRef(env, java_bytecode);
@@ -257,19 +266,29 @@ static JSModuleDef *load_module(JSContext *context, const char *module_name, voi
         }
     }
 
-    (*env)->DeleteLocalRef(env, content);
-    (*env)->DeleteLocalRef(env, java_name);
     if (JS_IsException(module)) {
-        return NULL;
+        goto notify_failure;
     }
     if (JS_VALUE_GET_TAG(module) != JS_TAG_MODULE) {
-        JS_FreeValue(context, module);
         JS_ThrowTypeError(context, "Content for '%s' is not an ES module.", module_name);
-        return NULL;
+        JS_FreeValue(context, module);
+        goto notify_failure;
     }
 
-    JSModuleDef *definition = JS_VALUE_GET_PTR(module);
+    definition = JS_VALUE_GET_PTR(module);
     JS_FreeValue(context, module);
+    goto cleanup_refs;
+
+notify_failure:
+    if (failure_version == globals->module_load_failure_version) {
+        notify_module_load_failed(env, globals, context, java_name, module_name);
+    }
+
+cleanup_refs:
+    if (content != NULL) {
+        (*env)->DeleteLocalRef(env, content);
+    }
+    (*env)->DeleteLocalRef(env, java_name);
     return definition;
 }
 
@@ -298,12 +317,18 @@ int install_module_loader(JNIEnv *env, JSRuntime *runtime, Globals *globals, job
             host_class,
             "onModuleCompiled",
             "(Ljava/lang/String;[B)V");
+    jmethodID on_module_load_failed_method = (*env)->GetMethodID(
+            env,
+            host_class,
+            "onModuleLoadFailed",
+            "(Ljava/lang/String;)V");
     (*env)->DeleteLocalRef(env, host_class);
 
     if (load_module_method == NULL ||
         get_module_source_method == NULL ||
         get_module_bytecode_method == NULL ||
-        on_module_compiled_method == NULL) {
+        on_module_compiled_method == NULL ||
+        on_module_load_failed_method == NULL) {
         return 0;
     }
 
@@ -312,6 +337,7 @@ int install_module_loader(JNIEnv *env, JSRuntime *runtime, Globals *globals, job
     globals->get_module_source_method = get_module_source_method;
     globals->get_module_bytecode_method = get_module_bytecode_method;
     globals->on_module_compiled_method = on_module_compiled_method;
+    globals->on_module_load_failed_method = on_module_load_failed_method;
     JS_SetModuleLoaderFunc(runtime, NULL, load_module, globals);
     return 1;
 }

--- a/quickjs/native/jni/quickjs_jni.c
+++ b/quickjs/native/jni/quickjs_jni.c
@@ -77,7 +77,8 @@ static void release_failed_globals_init(JNIEnv *env,
 JNIEXPORT jlong JNICALL Java_com_dokar_quickjs_QuickJs_initGlobals(JNIEnv *env,
                                                                    jobject this,
                                                                    jlong runtime_ptr,
-                                                                   jobjectArray classes) {
+                                                                   jobjectArray classes,
+                                                                   jboolean enable_module_loader) {
     // Suppress lint: We will free it in releaseGlobals()
 #pragma clang diagnostic push
 #pragma ide diagnostic ignored "MemoryLeak"
@@ -155,7 +156,8 @@ JNIEXPORT jlong JNICALL Java_com_dokar_quickjs_QuickJs_initGlobals(JNIEnv *env,
     // Handle unhandled promise rejections
     JS_SetHostPromiseRejectionTracker(runtime, promise_rejection_handler,
                                       global_host_ref);
-    if (!install_module_loader(env, runtime, globals, global_host_ref)) {
+    if (enable_module_loader == JNI_TRUE &&
+        !install_module_loader(env, runtime, globals, global_host_ref)) {
         jthrowable exception = try_catch_java_exceptions(env);
         if (exception == NULL) {
             exception = new_qjs_exception(env, "Cannot install module loader.");

--- a/quickjs/native/jni/quickjs_jni.c
+++ b/quickjs/native/jni/quickjs_jni.c
@@ -100,6 +100,8 @@ JNIEXPORT jlong JNICALL Java_com_dokar_quickjs_QuickJs_initGlobals(JNIEnv *env,
     globals->get_module_source_method = NULL;
     globals->get_module_bytecode_method = NULL;
     globals->on_module_compiled_method = NULL;
+    globals->on_module_load_failed_method = NULL;
+    globals->module_load_failure_version = 0;
 
     pthread_mutexattr_t mutex_attributes;
     pthread_mutexattr_init(&mutex_attributes);

--- a/quickjs/native/jni/quickjs_jni.h
+++ b/quickjs/native/jni/quickjs_jni.h
@@ -22,6 +22,10 @@ typedef struct {
     jmethodID get_module_bytecode_method;
     /** QuickJs.onModuleCompiled(String, ByteArray) notification callback. */
     jmethodID on_module_compiled_method;
+    /** QuickJs.onModuleLoadFailed(String) failure callback. */
+    jmethodID on_module_load_failed_method;
+    /** Monotonic counter used to suppress parent notifications after a nested failure. */
+    uint64_t module_load_failure_version;
     /**
      * Some JS values, used by C functions.
      */

--- a/quickjs/src/commonMain/kotlin/com/dokar/quickjs/ModuleLoader.kt
+++ b/quickjs/src/commonMain/kotlin/com/dokar/quickjs/ModuleLoader.kt
@@ -11,8 +11,9 @@ fun interface ModuleLoader {
      * Loads a normalized module name requested by QuickJS.
      *
      * Return source for a cache miss, compatible bytecode for a cache hit, or
-     * null when the module is unavailable. Unhandled exceptions fail the
-     * current compile, graph-resolution, or evaluation operation.
+     * null when the module is unavailable. Returning null or throwing an
+     * unhandled exception fails the current compile, graph-resolution, or
+     * evaluation operation and invokes [onLoadFailed] with this module name.
      *
      * @param name The normalized module name.
      * @return The module content, or null when it cannot be loaded.
@@ -25,7 +26,8 @@ fun interface ModuleLoader {
      * QuickJs does not retain the Kotlin byte array after this call. Callers may
      * keep it or enqueue it for asynchronous persistence. Callbacks already
      * delivered for earlier modules remain valid if later graph resolution
-     * fails. Unhandled exceptions fail the current operation.
+     * fails. An unhandled exception fails the current module loading attempt and
+     * invokes [onLoadFailed] with this module name.
      *
      * @param name The normalized module name.
      * @param bytecode The newly compiled module bytecode.
@@ -35,12 +37,21 @@ fun interface ModuleLoader {
     /**
      * Reports that QuickJS could not load a requested module.
      *
-     * This callback is delivered for both static and dynamic imports. A dynamic
-     * import still triggers the callback when JavaScript handles its rejection
-     * with `try/catch` or `Promise.catch`. The callback runs synchronously during
-     * module resolution, so callers should only enqueue invalidation work and
-     * must not re-enter the same [QuickJs] instance. Unhandled callback exceptions
-     * become the current module loading failure.
+     * The callback is invoked when:
+     *
+     * - [load] returns null or throws an exception.
+     * - Source or bytecode returned by [load] cannot be compiled, read, or validated.
+     * - [onCompiled] throws an exception.
+     *
+     * A failure notification does not consume the original module error:
+     *
+     * - Static imports and unhandled dynamic imports still fail the current operation.
+     * - A dynamic import handled with `try/catch` or `Promise.catch` can continue after
+     *   this callback.
+     *
+     * The callback runs synchronously during module resolution, so callers should only
+     * enqueue invalidation work and must not re-enter the same [QuickJs] instance.
+     * An unhandled callback exception becomes the current module loading failure.
      *
      * @param name The normalized name of the module that failed to load.
      */

--- a/quickjs/src/commonMain/kotlin/com/dokar/quickjs/ModuleLoader.kt
+++ b/quickjs/src/commonMain/kotlin/com/dokar/quickjs/ModuleLoader.kt
@@ -3,7 +3,7 @@ package com.dokar.quickjs
 /**
  * Supplies ES modules to one [QuickJs] runtime.
  *
- * Both callbacks run synchronously while QuickJS is resolving a module. They
+ * All callbacks run synchronously while QuickJS is resolving a module. They
  * must return quickly and must not re-enter the same [QuickJs] instance.
  */
 fun interface ModuleLoader {
@@ -31,6 +31,20 @@ fun interface ModuleLoader {
      * @param bytecode The newly compiled module bytecode.
      */
     fun onCompiled(name: String, bytecode: ByteArray) = Unit
+
+    /**
+     * Reports that QuickJS could not load a requested module.
+     *
+     * This callback is delivered for both static and dynamic imports. A dynamic
+     * import still triggers the callback when JavaScript handles its rejection
+     * with `try/catch` or `Promise.catch`. The callback runs synchronously during
+     * module resolution, so callers should only enqueue invalidation work and
+     * must not re-enter the same [QuickJs] instance. Unhandled callback exceptions
+     * become the current module loading failure.
+     *
+     * @param name The normalized name of the module that failed to load.
+     */
+    fun onLoadFailed(name: String) = Unit
 }
 
 /**
@@ -39,6 +53,7 @@ fun interface ModuleLoader {
 class ModuleLoaderBuilder internal constructor() {
     private var loadBlock: ((String) -> ModuleContent?)? = null
     private var onCompiledBlock: (String, ByteArray) -> Unit = { _, _ -> }
+    private var onLoadFailedBlock: (String) -> Unit = {}
 
     /**
      * Configures synchronous module lookup.
@@ -54,16 +69,28 @@ class ModuleLoaderBuilder internal constructor() {
         onCompiledBlock = block
     }
 
+    /**
+     * Configures immediate notification for failed module loading attempts.
+     */
+    fun onLoadFailed(block: (name: String) -> Unit) {
+        onLoadFailedBlock = block
+    }
+
     internal fun build(): ModuleLoader {
         val loadCallback = requireNotNull(loadBlock) {
             "ModuleLoader requires a load callback."
         }
         val onCompiledCallback = onCompiledBlock
+        val onLoadFailedCallback = onLoadFailedBlock
         return object : ModuleLoader {
             override fun load(name: String): ModuleContent? = loadCallback(name)
 
             override fun onCompiled(name: String, bytecode: ByteArray) {
                 onCompiledCallback(name, bytecode)
+            }
+
+            override fun onLoadFailed(name: String) {
+                onLoadFailedCallback(name)
             }
         }
     }

--- a/quickjs/src/commonTest/kotlin/com/dokar/quickjs/test/ModuleLoaderTest.kt
+++ b/quickjs/src/commonTest/kotlin/com/dokar/quickjs/test/ModuleLoaderTest.kt
@@ -373,6 +373,21 @@ class ModuleLoaderTest {
     }
 
     @Test
+    fun missingModuleWithoutLoaderKeepsBaseException() = runTest {
+        val failure = quickJs {
+            assertFailsWith<QuickJsException> {
+                evaluate<Any?>(
+                    "import 'missing';",
+                    filename = "entry",
+                    asModule = true,
+                )
+            }
+        }
+
+        assertEquals(QuickJsException::class, failure::class)
+    }
+
+    @Test
     fun corruptAndMismatchedBytecodeAreRejected() = runTest {
         val actualModule = quickJs {
             compile(

--- a/quickjs/src/commonTest/kotlin/com/dokar/quickjs/test/ModuleLoaderTest.kt
+++ b/quickjs/src/commonTest/kotlin/com/dokar/quickjs/test/ModuleLoaderTest.kt
@@ -433,7 +433,7 @@ class ModuleLoaderTest {
     }
 
     @Test
-    fun compileAndDynamicImportFailuresInvokeTheFailureCallback() = runTest {
+    fun compileAndUnhandledDynamicImportFailuresInvokeCallbackAndFailOperation() = runTest {
         val failed = mutableListOf<String>()
         val loader = moduleLoader {
             load { null }
@@ -611,7 +611,7 @@ class ModuleLoaderTest {
     }
 
     @Test
-    fun loaderAndCompilationCallbackExceptionsFailTheOperation() = runTest {
+    fun loaderAndCompilationCallbackExceptionsReportFailureAndFailOperation() = runTest {
         val failed = mutableListOf<String>()
         val loadFailure = moduleLoader {
             load { throw IllegalStateException("load failed") }
@@ -637,9 +637,11 @@ class ModuleLoaderTest {
         assertContains(compileError.message.orEmpty(), "load failed")
         assertEquals(listOf("dependency", "dependency"), failed)
 
+        val compilationCallbackFailures = mutableListOf<String>()
         val callbackFailure = moduleLoader {
             load { ModuleContent.Source("export const value = 42;") }
             onCompiled { _, _ -> throw IllegalStateException("persistence handoff failed") }
+            onLoadFailed { name -> compilationCallbackFailures += name }
         }
         val callbackError = quickJs(moduleLoader = callbackFailure) {
             assertFails {
@@ -647,6 +649,7 @@ class ModuleLoaderTest {
             }
         }
         assertContains(callbackError.message.orEmpty(), "persistence handoff failed")
+        assertEquals(listOf("dependency"), compilationCallbackFailures)
 
         val quickJsLoadFailure = moduleLoader {
             load { throw QuickJsException("custom loader failure") }

--- a/quickjs/src/commonTest/kotlin/com/dokar/quickjs/test/ModuleLoaderTest.kt
+++ b/quickjs/src/commonTest/kotlin/com/dokar/quickjs/test/ModuleLoaderTest.kt
@@ -259,6 +259,7 @@ class ModuleLoaderTest {
         }
 
         val compiledBeforeFailure = linkedMapOf<String, ByteArray>()
+        val failed = mutableListOf<String>()
         val incompleteLoader = moduleLoader {
             load { name ->
                 if (name == "first") {
@@ -268,6 +269,7 @@ class ModuleLoaderTest {
                 }
             }
             onCompiled { name, bytecode -> compiledBeforeFailure[name] = bytecode }
+            onLoadFailed { name -> failed += name }
         }
 
         quickJs(moduleLoader = incompleteLoader) {
@@ -276,6 +278,7 @@ class ModuleLoaderTest {
             }
         }
 
+        assertEquals(listOf("missing"), failed)
         assertEquals(setOf("first"), compiledBeforeFailure.keys)
         assertTrue(compiledBeforeFailure.getValue("first").isNotEmpty())
     }
@@ -356,20 +359,26 @@ class ModuleLoaderTest {
     }
 
     @Test
-    fun missingModuleFailsWithItsNormalizedName() = runTest {
-        val loader = moduleLoader { load { null } }
+    fun missingModuleFailureReportsItsNormalizedName() = runTest {
+        val failed = mutableListOf<String>()
+        val loader = moduleLoader {
+            load { null }
+            onLoadFailed { name -> failed += name }
+        }
 
         val failure = quickJs(moduleLoader = loader) {
             assertFailsWith<QuickJsException> {
                 evaluate<Any?>(
-                    "import 'missing';",
-                    filename = "entry",
+                    "import './missing.js';",
+                    filename = "app/entry.js",
                     asModule = true,
                 )
             }
         }
 
-        assertContains(failure.message.orEmpty(), "missing")
+        assertContains(failure.message.orEmpty(), "app/missing.js")
+        assertEquals(QuickJsException::class, failure::class)
+        assertEquals(listOf("app/missing.js"), failed)
     }
 
     @Test
@@ -397,17 +406,22 @@ class ModuleLoaderTest {
             )
         }
 
+        val corruptFailures = mutableListOf<String>()
         val corruptLoader = moduleLoader {
             load { ModuleContent.Bytecode(byteArrayOf(0, 1, 2, 3)) }
+            onLoadFailed { name -> corruptFailures += name }
         }
         quickJs(moduleLoader = corruptLoader) {
             assertFailsWith<QuickJsException> {
                 evaluate<Any?>("import 'corrupt';", asModule = true)
             }
         }
+        assertEquals(listOf("corrupt"), corruptFailures)
 
+        val mismatchFailures = mutableListOf<String>()
         val mismatchedLoader = moduleLoader {
             load { ModuleContent.Bytecode(actualModule) }
+            onLoadFailed { name -> mismatchFailures += name }
         }
         val mismatch = quickJs(moduleLoader = mismatchedLoader) {
             assertFailsWith<QuickJsException> {
@@ -415,6 +429,103 @@ class ModuleLoaderTest {
             }
         }
         assertContains(mismatch.message.orEmpty(), "expected")
+        assertEquals(listOf("expected"), mismatchFailures)
+    }
+
+    @Test
+    fun compileAndDynamicImportFailuresInvokeTheFailureCallback() = runTest {
+        val failed = mutableListOf<String>()
+        val loader = moduleLoader {
+            load { null }
+            onLoadFailed { name -> failed += name }
+        }
+
+        quickJs(moduleLoader = loader) {
+            assertFailsWith<QuickJsException> {
+                compile(
+                    "import 'compile-dependency';",
+                    filename = "compile-entry",
+                    asModule = true,
+                )
+            }
+        }
+        assertEquals(listOf("compile-dependency"), failed)
+
+        quickJs(moduleLoader = loader) {
+            assertFailsWith<QuickJsException> {
+                evaluate<Any?>(
+                    "await import('dynamic-dependency');",
+                    filename = "dynamic-entry",
+                    asModule = true,
+                )
+            }
+        }
+        assertEquals(listOf("compile-dependency", "dynamic-dependency"), failed)
+    }
+
+    @Test
+    fun handledDynamicImportFailureStillInvokesTheFailureCallback() = runTest {
+        val failed = mutableListOf<String>()
+        val loader = moduleLoader {
+            load { null }
+            onLoadFailed { name -> failed += name }
+        }
+
+        quickJs(moduleLoader = loader) {
+            evaluate<Any?>(
+                "try { await import('optional'); } catch (_) {}",
+                filename = "dynamic-entry",
+                asModule = true,
+            )
+        }
+
+        assertEquals(listOf("optional"), failed)
+    }
+
+    @Test
+    fun nestedDependencyFailureReportsTheInnermostModuleName() = runTest {
+        val failed = mutableListOf<String>()
+        val loader = moduleLoader {
+            load { name ->
+                when (name) {
+                    "parent" -> ModuleContent.Source("import 'corrupt-leaf';")
+                    "corrupt-leaf" -> ModuleContent.Bytecode(byteArrayOf(0, 1, 2, 3))
+                    else -> null
+                }
+            }
+            onLoadFailed { name -> failed += name }
+        }
+
+        quickJs(moduleLoader = loader) {
+            assertFailsWith<QuickJsException> {
+                evaluate<Any?>("import 'parent';", asModule = true)
+            }
+        }
+
+        assertEquals(listOf("corrupt-leaf"), failed)
+    }
+
+    @Test
+    fun runtimeFailureAfterModuleLoadingRemainsARegularQuickJsException() = runTest {
+        val failed = mutableListOf<String>()
+        val loader = moduleLoader {
+            load { ModuleContent.Source("export const value = 42;") }
+            onLoadFailed { name -> failed += name }
+        }
+
+        val failure = quickJs(moduleLoader = loader) {
+            assertFailsWith<QuickJsException> {
+                evaluate<Any?>(
+                    "import 'dependency'; throw new Error('execution failed');",
+                    filename = "entry",
+                    asModule = true,
+                )
+            }
+        }
+
+        assertEquals(QuickJsException::class, failure::class)
+        assertContains(failure.message.orEmpty(), "execution failed")
+        assertTrue(failed.isEmpty())
     }
 
     @Test
@@ -501,8 +612,10 @@ class ModuleLoaderTest {
 
     @Test
     fun loaderAndCompilationCallbackExceptionsFailTheOperation() = runTest {
+        val failed = mutableListOf<String>()
         val loadFailure = moduleLoader {
             load { throw IllegalStateException("load failed") }
+            onLoadFailed { name -> failed += name }
         }
         val loadError = quickJs(moduleLoader = loadFailure) {
             assertFails {
@@ -510,6 +623,7 @@ class ModuleLoaderTest {
             }
         }
         assertContains(loadError.message.orEmpty(), "load failed")
+        assertEquals(listOf("dependency"), failed)
 
         val compileError = quickJs(moduleLoader = loadFailure) {
             assertFails {
@@ -521,6 +635,7 @@ class ModuleLoaderTest {
             }
         }
         assertContains(compileError.message.orEmpty(), "load failed")
+        assertEquals(listOf("dependency", "dependency"), failed)
 
         val callbackFailure = moduleLoader {
             load { ModuleContent.Source("export const value = 42;") }
@@ -532,15 +647,38 @@ class ModuleLoaderTest {
             }
         }
         assertContains(callbackError.message.orEmpty(), "persistence handoff failed")
+
+        val quickJsLoadFailure = moduleLoader {
+            load { throw QuickJsException("custom loader failure") }
+        }
+        val quickJsLoadError = quickJs(moduleLoader = quickJsLoadFailure) {
+            assertFailsWith<QuickJsException> {
+                evaluate<Any?>("import 'dependency';", asModule = true)
+            }
+        }
+        assertEquals(QuickJsException::class, quickJsLoadError::class)
+
+        val failureCallbackError = moduleLoader {
+            load { null }
+            onLoadFailed { throw IllegalStateException("invalidation handoff failed") }
+        }
+        val invalidationError = quickJs(moduleLoader = failureCallbackError) {
+            assertFails {
+                evaluate<Any?>("import 'dependency';", asModule = true)
+            }
+        }
+        assertContains(invalidationError.message.orEmpty(), "invalidation handoff failed")
     }
 
     @Test
     fun invalidSourceCanBeCorrectedBeforeSuccessfulResolution() = runTest {
         var source = "export const value = ;"
+        val failed = mutableListOf<String>()
         val loader = moduleLoader {
             load { name ->
                 if (name == "recoverable") ModuleContent.Source(source) else null
             }
+            onLoadFailed { name -> failed += name }
         }
 
         var captured = 0
@@ -553,6 +691,7 @@ class ModuleLoaderTest {
                     asModule = true,
                 )
             }
+            assertEquals(listOf("recoverable"), failed)
 
             source = "export const value = 42;"
             evaluate<Any?>(

--- a/quickjs/src/jniMain/kotlin/com/dokar/quickjs/QuickJs.jni.kt
+++ b/quickjs/src/jniMain/kotlin/com/dokar/quickjs/QuickJs.jni.kt
@@ -241,7 +241,8 @@ actual class QuickJs private constructor(
             // exceptions outside the QuickJsException hierarchy.
             globals = initGlobals(
                 runtime,
-                arrayOf(Unit::class.java, UByteArray::class.java)
+                arrayOf(Unit::class.java, UByteArray::class.java),
+                moduleLoader != null,
             )
         } catch (error: Throwable) {
             close()
@@ -854,7 +855,11 @@ actual class QuickJs private constructor(
     @Throws(QuickJsException::class)
     private external fun newContext(runtime: Long): Long
 
-    private external fun initGlobals(runtime: Long, classes: Array<Class<*>>): Long
+    private external fun initGlobals(
+        runtime: Long,
+        classes: Array<Class<*>>,
+        enableModuleLoader: Boolean,
+    ): Long
 
     @Throws(QuickJsException::class)
     private external fun releaseGlobals(context: Long, globals: Long)

--- a/quickjs/src/jniMain/kotlin/com/dokar/quickjs/QuickJs.jni.kt
+++ b/quickjs/src/jniMain/kotlin/com/dokar/quickjs/QuickJs.jni.kt
@@ -629,6 +629,12 @@ actual class QuickJs private constructor(
         moduleLoader?.onCompiled(name, bytecode)
     }
 
+    /** Reports a failed module loading attempt to the runtime's loader. */
+    @Suppress("unused")
+    private fun onModuleLoadFailed(name: String) {
+        moduleLoader?.onLoadFailed(name)
+    }
+
     /** Loads queued modules using the legacy addModule behavior. */
     private suspend fun loadModules(session: EvaluationSession) = jsMutex.withLock {
         ensureNotClosed()

--- a/quickjs/src/jniMain/resources/META-INF/native-image/com.dokar.quickjs/quickjs/reachability-metadata.json
+++ b/quickjs/src/jniMain/resources/META-INF/native-image/com.dokar.quickjs/quickjs/reachability-metadata.json
@@ -407,6 +407,12 @@
           ]
         },
         {
+          "name": "onModuleLoadFailed",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
           "name": "setEvalException",
           "parameterTypes": [
             "java.lang.Throwable"

--- a/quickjs/src/nativeMain/kotlin/com/dokar/quickjs/QuickJs.native.kt
+++ b/quickjs/src/nativeMain/kotlin/com/dokar/quickjs/QuickJs.native.kt
@@ -105,6 +105,9 @@ actual class QuickJs private constructor(
 
     private val modules = mutableListOf<ByteArray>()
     private var resolvingModuleNames: LinkedHashSet<String>? = null
+    /** Suppresses parent notifications after a nested synchronous loader failure. */
+    internal var moduleLoadFailureVersion = 0L
+        private set
 
     private val jobsMutex = Mutex()
     private val asyncJobs = mutableListOf<AsyncJob>()
@@ -580,6 +583,12 @@ actual class QuickJs private constructor(
     /** Delivers source-compiled bytecode to the runtime-scoped module loader. */
     internal fun onModuleCompiled(name: String, bytecode: ByteArray) {
         moduleLoader?.onCompiled(name, bytecode)
+    }
+
+    /** Reports a failed module loading attempt to the runtime's loader. */
+    internal fun onModuleLoadFailed(name: String) {
+        moduleLoadFailureVersion++
+        moduleLoader?.onLoadFailed(name)
     }
 
     /** Loads queued modules using the legacy addModule behavior. */

--- a/quickjs/src/nativeMain/kotlin/com/dokar/quickjs/bridge/moduleLoader.kt
+++ b/quickjs/src/nativeMain/kotlin/com/dokar/quickjs/bridge/moduleLoader.kt
@@ -113,6 +113,29 @@ private fun readModuleName(
     }
 }
 
+/** Reports a loader failure and forwards the original or callback error to QuickJS. */
+@OptIn(ExperimentalForeignApi::class)
+private fun throwModuleLoadFailure(
+    context: CPointer<JSContext>,
+    quickJs: QuickJs,
+    name: String,
+    error: Throwable,
+    failureVersion: Long,
+): CPointer<JSModuleDef>? {
+    val failure = if (failureVersion == quickJs.moduleLoadFailureVersion) {
+        try {
+            quickJs.onModuleLoadFailed(name)
+            error
+        } catch (callbackError: Throwable) {
+            callbackError
+        }
+    } else {
+        error
+    }
+    JS_Throw(context, ktErrorToJsError(context, failure))
+    return null
+}
+
 @OptIn(ExperimentalForeignApi::class)
 private fun loadModule(
   context: CPointer<JSContext>?,
@@ -121,10 +144,17 @@ private fun loadModule(
 ): CPointer<JSModuleDef>? {
   val jsContext = context ?: return null
   val quickJs = opaque?.asStableRef<QuickJs>()?.get()
-  return try {
-    val name = moduleName?.toKStringFromUtf8()
+  val (name, owner) = try {
+    val resolvedName = moduleName?.toKStringFromUtf8()
       ?: qjsError("Missing ES module name.")
-    val owner = quickJs ?: qjsError("Missing QuickJs module loader state.")
+    val resolvedOwner = quickJs ?: qjsError("Missing QuickJs module loader state.")
+    resolvedName to resolvedOwner
+  } catch (error: Throwable) {
+    JS_Throw(jsContext, ktErrorToJsError(jsContext, error))
+    return null
+  }
+  val failureVersion = owner.moduleLoadFailureVersion
+  val definition = try {
     when (val content = owner.loadModule(name)
       ?: qjsError("could not load module '$name'")) {
       is ModuleContent.Source -> compileSourceModule(
@@ -141,9 +171,22 @@ private fun loadModule(
       )
     }
   } catch (error: Throwable) {
-    JS_Throw(jsContext, ktErrorToJsError(jsContext, error))
-    null
+    return throwModuleLoadFailure(
+      context = jsContext,
+      quickJs = owner,
+      name = name,
+      error = error,
+      failureVersion = failureVersion,
+    )
   }
+  if (definition == null && failureVersion == owner.moduleLoadFailureVersion) {
+    try {
+      owner.onModuleLoadFailed(name)
+    } catch (error: Throwable) {
+      JS_Throw(jsContext, ktErrorToJsError(jsContext, error))
+    }
+  }
+  return definition
 }
 
 /** Installs the runtime-scoped host module loader. */


### PR DESCRIPTION
## Background

After [PR #213](https://github.com/dokar3/quickjs-kt/pull/213) introduced the Module Loader, callers still could not identify which module failed to load, making it difficult to invalidate corrupted or stale bytecode caches.

Additionally, JNI installed the loader bridge by default, while Kotlin/Native installed it only when a `ModuleLoader` was configured. This PR aligns the behavior across both implementations.

## Changes

- Add a default no-op `ModuleLoader.onLoadFailed(name)` callback.
- Report failures for static imports, dynamic imports, and dynamic import rejections handled by JavaScript.
- Install the JNI loader bridge only when a `ModuleLoader` is configured, matching Kotlin/Native.
- Add documentation and regression tests.

## Usage

```kotlin
val loader = moduleLoader {
    load { name -> loadModule(name) }
    onCompiled { name, bytecode -> saveBytecode(name, bytecode) }
    onLoadFailed { name -> enqueueBytecodeInvalidation(name) }
}
```

All loader callbacks run synchronously. They should not block or re-enter the current `QuickJs` runtime. `onLoadFailed` should preferably enqueue cache invalidation work for asynchronous processing.

## Tests

JVM and macOS ARM64 tests pass, covering static and dynamic imports, handled rejections, invalid bytecode, nested dependencies, and retries after failures.

The code and tests in this PR were implemented by Codex GPT-5.6-sol.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `onLoadFailed` callback for static and dynamic module-loading failures.
  * Failure notifications include the affected module name, including nested dependency failures.
  * Added guidance for handling failed modules and invalidating cached content.

* **Bug Fixes**
  * Preserved original JavaScript exceptions when failure callbacks encounter errors.
  * Prevented runtime execution errors from being reported as module-load failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->