### PR TITLE
Fix binding exception propagation

### DIFF
--- a/quickjs/native/jni/binding_bridge.c
+++ b/quickjs/native/jni/binding_bridge.c
@@ -12,9 +12,8 @@
 
 #define GLOBAL_THIS_HANDLE -1
 
-void set_eval_exception_to_caller(JNIEnv *env, jobject call_host, jthrowable exception) {
-    jmethodID set_exception_method = method_quick_js_set_eval_exception(env);
-    (*env)->CallVoidMethod(env, call_host, set_exception_method, exception);
+static JSValue throw_java_exception(JNIEnv *env, JSContext *context, jthrowable exception) {
+    return JS_Throw(context, java_throwable_to_js_error(env, context, exception));
 }
 
 JSValue jni_invoke_getter(JSContext *context, jobject call_host, int64_t object_handle,
@@ -32,9 +31,9 @@ JSValue jni_invoke_getter(JSContext *context, jobject call_host, int64_t object_
     // Check java exceptions
     jthrowable exception = try_catch_java_exceptions(env);
     if (exception != NULL) {
-        set_eval_exception_to_caller(env, call_host, exception);
+        JSValue js_exception = throw_java_exception(env, context, exception);
         (*env)->DeleteLocalRef(env, exception);
-        return JS_EXCEPTION;
+        return js_exception;
     }
     if (result == NULL) {
         return JS_NULL;
@@ -55,10 +54,10 @@ JSValue jni_invoke_setter(JSContext *context, jobject call_host, int64_t object_
     // Check mapping exceptions
     jthrowable mapping_exception = try_catch_java_exceptions(env);
     if (mapping_exception != NULL) {
-        set_eval_exception_to_caller(env, call_host, mapping_exception);
+        JSValue js_exception = throw_java_exception(env, context, mapping_exception);
         (*env)->DeleteLocalRef(env, value);
         (*env)->DeleteLocalRef(env, mapping_exception);
-        return JS_EXCEPTION;
+        return js_exception;
     }
     // Don't release
     jstring java_name = (*env)->NewStringUTF(env, property_name);
@@ -68,9 +67,9 @@ JSValue jni_invoke_setter(JSContext *context, jobject call_host, int64_t object_
     // Check java exceptions
     jthrowable exception = try_catch_java_exceptions(env);
     if (exception != NULL) {
-        set_eval_exception_to_caller(env, call_host, exception);
+        JSValue js_exception = throw_java_exception(env, context, exception);
         (*env)->DeleteLocalRef(env, exception);
-        return JS_EXCEPTION;
+        return js_exception;
     }
     return JS_UNDEFINED;
 }
@@ -87,10 +86,10 @@ JSValue jni_invoke_function(JSContext *context, jobject call_host, int64_t objec
         // Check mapping exceptions
         jthrowable exception = try_catch_java_exceptions(env);
         if (exception != NULL) {
-            set_eval_exception_to_caller(env, call_host, exception);
+            JSValue js_exception = throw_java_exception(env, context, exception);
             (*env)->DeleteLocalRef(env, arg);
             (*env)->DeleteLocalRef(env, exception);
-            return JS_EXCEPTION;
+            return js_exception;
         }
         (*env)->SetObjectArrayElement(env, args, i, arg);
         (*env)->DeleteLocalRef(env, arg);
@@ -106,9 +105,9 @@ JSValue jni_invoke_function(JSContext *context, jobject call_host, int64_t objec
     // Check java exceptions
     jthrowable exception = try_catch_java_exceptions(env);
     if (exception != NULL) {
-        set_eval_exception_to_caller(env, call_host, exception);
+        JSValue js_exception = throw_java_exception(env, context, exception);
         (*env)->DeleteLocalRef(env, exception);
-        return JS_EXCEPTION;
+        return js_exception;
     }
     return jobject_to_js_value(env, context, NULL, result);
 }
@@ -134,10 +133,10 @@ JSValue jni_invoke_async_function(JSContext *context, jobject call_host,
         // Check mapping exceptions
         jthrowable exception = try_catch_java_exceptions(env);
         if (exception != NULL) {
-            set_eval_exception_to_caller(env, call_host, exception);
+            JSValue js_exception = throw_java_exception(env, context, exception);
             (*env)->DeleteLocalRef(env, arg);
             (*env)->DeleteLocalRef(env, exception);
-            return JS_EXCEPTION;
+            return js_exception;
         }
         (*env)->SetObjectArrayElement(env, args, i + (args_len - argc), arg);
         (*env)->DeleteLocalRef(env, arg);
@@ -153,9 +152,9 @@ JSValue jni_invoke_async_function(JSContext *context, jobject call_host,
     // Check java exceptions
     jthrowable exception = try_catch_java_exceptions(env);
     if (exception != NULL) {
-        set_eval_exception_to_caller(env, call_host, exception);
+        JSValue js_exception = throw_java_exception(env, context, exception);
         (*env)->DeleteLocalRef(env, exception);
-        return JS_EXCEPTION;
+        return js_exception;
     }
     // No return value needs to handle
     return JS_UNDEFINED;

--- a/quickjs/native/jni/mapping/jobject_to_js_value.h
+++ b/quickjs/native/jni/mapping/jobject_to_js_value.h
@@ -9,5 +9,9 @@
  */
 JSValue jobject_to_js_value(JNIEnv *env, JSContext *context, jobject visited_set, jobject value);
 
+/**
+ * Convert a Java throwable to a JavaScript Error.
+ */
+JSValue java_throwable_to_js_error(JNIEnv *env, JSContext *context, jthrowable throwable);
 
 #endif //QJS_KT_JOBJECT_TO_JS_VALUE_H

--- a/quickjs/native/jni/mapping/js_value_to_jobject.c
+++ b/quickjs/native/jni/mapping/js_value_to_jobject.c
@@ -91,11 +91,7 @@ jthrowable js_error_to_java_error(JNIEnv *env, JSContext *context, JSValue error
     if (original_name != NULL) {
         JS_FreeCString(context, original_name);
     }
-    if (original_message != NULL) {
-        JS_FreeCString(context, original_message);
-    }
     JS_FreeValue(context, js_name);
-    JS_FreeValue(context, js_message);
 
     if (java_error_cls != NULL) {
         jmethodID constructor = (*env)->GetMethodID(env, java_error_cls, "<init>",
@@ -106,11 +102,20 @@ jthrowable js_error_to_java_error(JNIEnv *env, JSContext *context, JSValue error
             jthrowable java_error = (*env)->NewObject(env, java_error_cls, constructor,
                                                       java_message);
             (*env)->DeleteLocalRef(env, java_message);
+            if (original_message != NULL) {
+                JS_FreeCString(context, original_message);
+            }
+            JS_FreeValue(context, js_message);
             free(full_message);
             free(stack);
             return java_error;
         }
     }
+
+    if (original_message != NULL) {
+        JS_FreeCString(context, original_message);
+    }
+    JS_FreeValue(context, js_message);
 
     // Fallback to the default error class
     jthrowable java_error = new_js_error_exception(env, context, error, full_message, stack);

--- a/quickjs/native/jni/mapping/js_value_to_jobject.c
+++ b/quickjs/native/jni/mapping/js_value_to_jobject.c
@@ -102,7 +102,7 @@ jthrowable js_error_to_java_error(JNIEnv *env, JSContext *context, JSValue error
                                                     "(Ljava/lang/String;)V");
         jthrowable e = try_catch_java_exceptions(env);
         if (e == NULL && constructor != NULL) {
-            jstring java_message = (*env)->NewStringUTF(env, full_message);
+            jstring java_message = (*env)->NewStringUTF(env, message);
             jthrowable java_error = (*env)->NewObject(env, java_error_cls, constructor,
                                                       java_message);
             (*env)->DeleteLocalRef(env, java_message);

--- a/quickjs/src/commonTest/kotlin/com/dokar/quickjs/test/EvalErrorsTest.kt
+++ b/quickjs/src/commonTest/kotlin/com/dokar/quickjs/test/EvalErrorsTest.kt
@@ -1,6 +1,7 @@
 package com.dokar.quickjs.test
 
 import com.dokar.quickjs.QuickJsException
+import com.dokar.quickjs.binding.asyncFunction
 import com.dokar.quickjs.binding.define
 import com.dokar.quickjs.binding.function
 import com.dokar.quickjs.quickJs
@@ -9,8 +10,10 @@ import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class EvalErrorsTest {
     @Test
@@ -119,6 +122,55 @@ class EvalErrorsTest {
             }
         }.also {
             assertContains(it.message!!, "Something wrong")
+        }
+    }
+
+    @Test
+    fun syncBindingExceptionAfterAwaitPreservesTypeAndMessage() = runTest {
+        quickJs {
+            asyncFunction("doNothing") {}
+            function("throwError") { throw IllegalArgumentException("boom") }
+
+            val exception = assertFailsWith<IllegalArgumentException> {
+                evaluate<Any?>(
+                    "await doNothing(); throwError()",
+                    filename = "test.js",
+                    asModule = true,
+                )
+            }
+
+            assertEquals(IllegalArgumentException::class, exception::class)
+            assertEquals("boom", exception.message)
+        }
+    }
+
+    @Test
+    fun syncBindingExceptionAfterAwaitCanBeCaughtByJavaScript() = runTest {
+        quickJs {
+            var caughtName: String? = null
+            var caughtMessage: String? = null
+            asyncFunction("doNothing") {}
+            function("throwError") { throw IllegalArgumentException("boom") }
+            function("capture") { args ->
+                caughtName = args[0] as String
+                caughtMessage = args[1] as String
+            }
+
+            evaluate<Any?>(
+                """
+                    await doNothing();
+                    try {
+                        throwError();
+                    } catch (e) {
+                        capture(e.name, e.message);
+                    }
+                """.trimIndent(),
+                filename = "test.js",
+                asModule = true,
+            )
+
+            assertTrue(caughtName.orEmpty().endsWith("IllegalArgumentException"))
+            assertEquals("boom", caughtMessage)
         }
     }
 

--- a/quickjs/src/nativeMain/kotlin/com/dokar/quickjs/bridge/jsValueToKtValue.kt
+++ b/quickjs/src/nativeMain/kotlin/com/dokar/quickjs/bridge/jsValueToKtValue.kt
@@ -211,30 +211,30 @@ private fun joinStackFrames(context: CPointer<JSContext>, stack: CValue<JSValue>
 }
 
 private fun newKtError(name: String, message: String?, stack: String?): Throwable {
-    val m = if (!stack.isNullOrEmpty()) "$message\n$stack" else message
+    val messageWithStack = if (!stack.isNullOrEmpty()) "$message\n$stack" else message
     // Try to restore the error class from the js error name
     @Suppress("DEPRECATION")
     return when (name) {
-        Throwable::class.qualifiedName -> Throwable(m)
-        Error::class.qualifiedName -> Error(m)
-        Exception::class.qualifiedName -> Exception(m)
-        RuntimeException::class.qualifiedName -> RuntimeException(m)
-        NullPointerException::class.qualifiedName -> NullPointerException(m)
-        NoSuchElementException::class.qualifiedName -> NoSuchElementException(m)
-        IllegalArgumentException::class.qualifiedName -> IllegalStateException(m)
-        IllegalStateException::class.qualifiedName -> IllegalStateException(m)
-        UnsupportedOperationException::class.qualifiedName -> UnsupportedOperationException(m)
-        IndexOutOfBoundsException::class.qualifiedName -> IndexOutOfBoundsException(m)
-        ClassCastException::class.qualifiedName -> ClassCastException(m)
-        ArithmeticException::class.qualifiedName -> ArithmeticException(m)
-        AssertionError::class.qualifiedName -> AssertionError(m)
-        OutOfMemoryError::class.qualifiedName -> OutOfMemoryError(m)
-        NumberFormatException::class.qualifiedName -> NumberFormatException(m)
-        ConcurrentModificationException::class.qualifiedName -> ConcurrentModificationException(m)
-        NotImplementedError::class.qualifiedName -> NotImplementedError(m ?: "")
-        QuickJsException::class.qualifiedName -> QuickJsException(m, stack)
+        Throwable::class.qualifiedName -> Throwable(message)
+        Error::class.qualifiedName -> Error(message)
+        Exception::class.qualifiedName -> Exception(message)
+        RuntimeException::class.qualifiedName -> RuntimeException(message)
+        NullPointerException::class.qualifiedName -> NullPointerException(message)
+        NoSuchElementException::class.qualifiedName -> NoSuchElementException(message)
+        IllegalArgumentException::class.qualifiedName -> IllegalArgumentException(message)
+        IllegalStateException::class.qualifiedName -> IllegalStateException(message)
+        UnsupportedOperationException::class.qualifiedName -> UnsupportedOperationException(message)
+        IndexOutOfBoundsException::class.qualifiedName -> IndexOutOfBoundsException(message)
+        ClassCastException::class.qualifiedName -> ClassCastException(message)
+        ArithmeticException::class.qualifiedName -> ArithmeticException(message)
+        AssertionError::class.qualifiedName -> AssertionError(message)
+        OutOfMemoryError::class.qualifiedName -> OutOfMemoryError(message)
+        NumberFormatException::class.qualifiedName -> NumberFormatException(message)
+        ConcurrentModificationException::class.qualifiedName -> ConcurrentModificationException(message)
+        NotImplementedError::class.qualifiedName -> NotImplementedError(message ?: "")
+        QuickJsException::class.qualifiedName -> QuickJsException(messageWithStack, stack)
         // Unknown error, add the name back
-        else -> QuickJsException("$name: $m", stack)
+        else -> QuickJsException("$name: $messageWithStack", stack)
     }
 }
 


### PR DESCRIPTION
Fix #222 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved exception handling for failures during synchronous and asynchronous JavaScript calls.
  - Preserved Kotlin exception types and messages when errors cross the JavaScript bridge.
  - Correctly restores `IllegalArgumentException` errors.
  - Improved JavaScript error names, messages, and stack information.
  - JavaScript can now catch converted binding exceptions with the expected details.
  - Resolved errors now use clearer messages when the original exception details are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->