### PR TITLE
Fix Unicode and emoji handling in JNI string conversions

### DIFF
--- a/quickjs/native/CMakeLists.txt
+++ b/quickjs/native/CMakeLists.txt
@@ -120,7 +120,7 @@ list(APPEND all_sources ${quickjs_sources})
 
 if (BUILD_WITH_JNI)
     # Bridge sources
-    file(GLOB_RECURSE bridge_sources
+    file(GLOB_RECURSE bridge_sources CONFIGURE_DEPENDS
             "jni/*.c"
             "jni/mapping/*.c")
     list(APPEND all_sources ${bridge_sources})

--- a/quickjs/native/jni/binding_bridge.c
+++ b/quickjs/native/jni/binding_bridge.c
@@ -7,6 +7,7 @@
 #include "jobject_to_js_value.h"
 #include "js_value_util.h"
 #include "jni_types_util.h"
+#include "jni_string_util.h"
 
 #define COMMON_FUNC_DATA_LEN 2
 
@@ -17,13 +18,16 @@ static JSValue throw_java_exception(JNIEnv *env, JSContext *context, jthrowable 
 }
 
 JSValue jni_invoke_getter(JSContext *context, jobject call_host, int64_t object_handle,
-                          const char *property_name) {
+                          const char *property_name, size_t property_name_length) {
     JNIEnv *env = get_jni_env();
     if (env == NULL) {
         return JS_EXCEPTION;
     }
-    // Don't release
-    jstring java_name = (*env)->NewStringUTF(env, property_name);
+    // QuickJS returns standard UTF-8, so decode its explicit length instead of using Modified UTF-8.
+    jstring java_name = jni_string_from_utf8(env, property_name, property_name_length);
+    if (java_name == NULL) {
+        return JS_EXCEPTION;
+    }
     jobject result = (*env)->CallObjectMethod(env, call_host,
                                               method_quick_js_on_call_getter(env),
                                               object_handle, java_name);
@@ -42,7 +46,8 @@ JSValue jni_invoke_getter(JSContext *context, jobject call_host, int64_t object_
 }
 
 JSValue jni_invoke_setter(JSContext *context, jobject call_host, int64_t object_handle,
-                          const char *property_name, int argc, JSValueConst *argv) {
+                          const char *property_name, size_t property_name_length,
+                          int argc, JSValueConst *argv) {
     JNIEnv *env = get_jni_env();
     if (env == NULL) {
         return JS_EXCEPTION;
@@ -59,8 +64,11 @@ JSValue jni_invoke_setter(JSContext *context, jobject call_host, int64_t object_
         (*env)->DeleteLocalRef(env, mapping_exception);
         return js_exception;
     }
-    // Don't release
-    jstring java_name = (*env)->NewStringUTF(env, property_name);
+    jstring java_name = jni_string_from_utf8(env, property_name, property_name_length);
+    if (java_name == NULL) {
+        (*env)->DeleteLocalRef(env, value);
+        return JS_EXCEPTION;
+    }
     (*env)->CallVoidMethod(env, call_host, method_quick_js_on_call_setter(env),
                            object_handle, java_name, value);
     (*env)->DeleteLocalRef(env, java_name);
@@ -75,7 +83,8 @@ JSValue jni_invoke_setter(JSContext *context, jobject call_host, int64_t object_
 }
 
 JSValue jni_invoke_function(JSContext *context, jobject call_host, int64_t object_handle,
-                            const char *function_name, int argc, JSValueConst *argv) {
+                            const char *function_name, size_t function_name_length,
+                            int argc, JSValueConst *argv) {
     JNIEnv *env = get_jni_env();
     if (env == NULL) {
         return JS_EXCEPTION;
@@ -94,8 +103,11 @@ JSValue jni_invoke_function(JSContext *context, jobject call_host, int64_t objec
         (*env)->SetObjectArrayElement(env, args, i, arg);
         (*env)->DeleteLocalRef(env, arg);
     }
-    // Don't release
-    jstring java_name = (*env)->NewStringUTF(env, function_name);
+    jstring java_name = jni_string_from_utf8(env, function_name, function_name_length);
+    if (java_name == NULL) {
+        (*env)->DeleteLocalRef(env, args);
+        return JS_EXCEPTION;
+    }
     jobject result = (*env)->CallObjectMethod(env, call_host,
                                               method_quick_js_on_call_function(env),
                                               object_handle,
@@ -114,7 +126,7 @@ JSValue jni_invoke_function(JSContext *context, jobject call_host, int64_t objec
 
 JSValue jni_invoke_async_function(JSContext *context, jobject call_host,
                                   int64_t object_handle,
-                                  const char *function_name,
+                                  const char *function_name, size_t function_name_length,
                                   uint64_t resolve_handle,
                                   uint64_t reject_handle,
                                   int argc, JSValueConst *argv) {
@@ -141,8 +153,11 @@ JSValue jni_invoke_async_function(JSContext *context, jobject call_host,
         (*env)->SetObjectArrayElement(env, args, i + (args_len - argc), arg);
         (*env)->DeleteLocalRef(env, arg);
     }
-    // Don't release
-    jstring java_name = (*env)->NewStringUTF(env, function_name);
+    jstring java_name = jni_string_from_utf8(env, function_name, function_name_length);
+    if (java_name == NULL) {
+        (*env)->DeleteLocalRef(env, args);
+        return JS_EXCEPTION;
+    }
     (*env)->CallObjectMethod(env, call_host,
                              method_quick_js_on_call_function(env),
                              object_handle,
@@ -168,9 +183,14 @@ property_getter(JSContext *context, JSValueConst this_val, int argc, JSValueCons
     jobject call_host = (jobject) host_address;
     int64_t object_handle;
     JS_ToInt64Ext(context, &object_handle, func_data[1]);
-    const char *prop_name = JS_ToCString(context, func_data[2]);
+    size_t prop_name_length;
+    const char *prop_name = JS_ToCStringLen(context, &prop_name_length, func_data[2]);
+    if (prop_name == NULL) {
+        return JS_EXCEPTION;
+    }
 
-    JSValue result = jni_invoke_getter(context, call_host, object_handle, prop_name);
+    JSValue result = jni_invoke_getter(
+            context, call_host, object_handle, prop_name, prop_name_length);
 
     JS_FreeCString(context, prop_name);
 
@@ -185,9 +205,14 @@ property_setter(JSContext *context, JSValueConst this_val, int argc, JSValueCons
     jobject call_host = (jobject) host_address;
     int64_t object_handle;
     JS_ToInt64Ext(context, &object_handle, func_data[1]);
-    const char *prop_name = JS_ToCString(context, func_data[2]);
+    size_t prop_name_length;
+    const char *prop_name = JS_ToCStringLen(context, &prop_name_length, func_data[2]);
+    if (prop_name == NULL) {
+        return JS_EXCEPTION;
+    }
 
-    JSValue result = jni_invoke_setter(context, call_host, object_handle, prop_name, argc, argv);
+    JSValue result = jni_invoke_setter(
+            context, call_host, object_handle, prop_name, prop_name_length, argc, argv);
 
     JS_FreeCString(context, prop_name);
 
@@ -202,9 +227,14 @@ function_invoke(JSContext *context, JSValueConst this_val, int argc, JSValueCons
     jobject call_host = (jobject) host_address;
     int64_t object_handle;
     JS_ToInt64Ext(context, &object_handle, func_data[1]);
-    const char *func_name = JS_ToCString(context, func_data[2]);
+    size_t func_name_length;
+    const char *func_name = JS_ToCStringLen(context, &func_name_length, func_data[2]);
+    if (func_name == NULL) {
+        return JS_EXCEPTION;
+    }
 
-    JSValue result = jni_invoke_function(context, call_host, object_handle, func_name, argc, argv);
+    JSValue result = jni_invoke_function(
+            context, call_host, object_handle, func_name, func_name_length, argc, argv);
 
     JS_FreeCString(context, func_name);
 
@@ -229,7 +259,12 @@ JSValue async_function_invoke(JSContext *context, JSValueConst this_val,
     JS_ToInt64Ext(context, &object_handle, func_data[1]);
 
     // Get the function name
-    const char *function_name = JS_ToCString(context, func_data[2]);
+    size_t function_name_length;
+    const char *function_name = JS_ToCStringLen(
+            context, &function_name_length, func_data[2]);
+    if (function_name == NULL) {
+        return JS_EXCEPTION;
+    }
 
     // Get globals
     int64_t globals_address_low;
@@ -252,7 +287,8 @@ JSValue async_function_invoke(JSContext *context, JSValueConst this_val,
 
     // Call java function
     JSValue result = jni_invoke_async_function(context, call_host, object_handle,
-                                               function_name, resolve_handle, reject_handle,
+                                               function_name, function_name_length,
+                                               resolve_handle, reject_handle,
                                                argc, argv);
 
     JS_FreeCString(context, function_name);
@@ -274,6 +310,7 @@ void define_async_js_function_on(JSContext *context,
                                  Globals *globals,
                                  JSValue parent,
                                  const char *name,
+                                 size_t name_length,
                                  int func_data_len,
                                  JSValue *func_data) {
     // Append the globals pointer to the function data
@@ -297,7 +334,7 @@ void define_async_js_function_on(JSContext *context,
                                          async_func_data_len,
                                          async_func_data);
     int flags = JS_PROP_CONFIGURABLE;
-    JSAtom prop = JS_NewAtom(context, name);
+    JSAtom prop = JS_NewAtomLen(context, name, name_length);
     // Define async function
     JS_DefinePropertyValue(context, parent, prop, invoke, flags);
     JS_FreeAtom(context, prop);
@@ -306,11 +343,12 @@ void define_async_js_function_on(JSContext *context,
 void define_js_function_on(JSContext *context,
                            JSValue parent,
                            const char *name,
+                           size_t name_length,
                            int func_data_len,
                            JSValue *func_data) {
     JSValue invoke = JS_NewCFunctionData(context, function_invoke, 0, 0, func_data_len, func_data);
     int flags = JS_PROP_CONFIGURABLE;
-    JSAtom prop = JS_NewAtom(context, name);
+    JSAtom prop = JS_NewAtomLen(context, name, name_length);
     // Define function
     JS_DefinePropertyValue(context, parent, prop, invoke, flags);
     JS_FreeAtom(context, prop);
@@ -331,7 +369,12 @@ void define_js_functions_on(JNIEnv *env,
     for (jsize i = 0; i < func_size; i++) {
         jobject j_fun = (*env)->GetObjectArrayElement(env, functions, i);
         jstring j_fun_name = (*env)->GetObjectField(env, j_fun, field_name);
-        const char *func_name = (*env)->GetStringUTFChars(env, j_fun_name, NULL);
+        JniUtf8String func_name;
+        if (!jni_string_to_utf8(env, j_fun_name, &func_name)) {
+            (*env)->DeleteLocalRef(env, j_fun_name);
+            (*env)->DeleteLocalRef(env, j_fun);
+            return;
+        }
         jboolean is_async = (*env)->GetBooleanField(env, j_fun, field_is_async);
 
         // Function data
@@ -340,18 +383,22 @@ void define_js_functions_on(JNIEnv *env,
         for (int j = 0; j < data_len - 1; j++) {
             func_data[j] = common_func_data[j];
         }
-        JSValue js_func_name = JS_NewString(context, func_name);
+        JSValue js_func_name = JS_NewStringLen(context, func_name.data, func_name.length);
         cvector_push_back(globals->managed_js_values, js_func_name);
         func_data[data_len - 1] = js_func_name;
 
         if (is_async) {
-            define_async_js_function_on(context, globals, parent, func_name, data_len, func_data);
+            define_async_js_function_on(
+                    context, globals, parent, func_name.data, func_name.length,
+                    data_len, func_data);
         } else {
-            define_js_function_on(context, parent, func_name, data_len, func_data);
+            define_js_function_on(
+                    context, parent, func_name.data, func_name.length, data_len, func_data);
         }
 
-        (*env)->ReleaseStringUTFChars(env, j_fun_name, func_name);
+        jni_utf8_string_release(&func_name);
         (*env)->DeleteLocalRef(env, j_fun_name);
+        (*env)->DeleteLocalRef(env, j_fun);
     }
 }
 
@@ -385,7 +432,13 @@ JSValue define_js_object(JNIEnv *env, JSContext *context,
         jobject element = (*env)->GetObjectArrayElement(env, properties, i);
 
         jstring j_prop_name = (*env)->GetObjectField(env, element, field_js_property_name(env));
-        const char *prop_name = (*env)->GetStringUTFChars(env, j_prop_name, NULL);
+        JniUtf8String prop_name;
+        if (!jni_string_to_utf8(env, j_prop_name, &prop_name)) {
+            (*env)->DeleteLocalRef(env, j_prop_name);
+            (*env)->DeleteLocalRef(env, element);
+            JS_FreeValue(context, object);
+            return JS_EXCEPTION;
+        }
         jboolean configurable = (*env)->GetBooleanField(env, element,
                                                         field_js_property_configurable(env));
         jboolean writable = (*env)->GetBooleanField(env, element, field_js_property_writable(env));
@@ -398,7 +451,7 @@ JSValue define_js_object(JNIEnv *env, JSContext *context,
         for (int j = 0; j < data_len - 1; j++) {
             func_data[j] = common_func_data[j];
         }
-        JSValue js_prop_name = JS_NewString(context, prop_name);
+        JSValue js_prop_name = JS_NewStringLen(context, prop_name.data, prop_name.length);
         cvector_push_back(globals->managed_js_values, js_prop_name);
         func_data[data_len - 1] = js_prop_name;
 
@@ -414,7 +467,7 @@ JSValue define_js_object(JNIEnv *env, JSContext *context,
             flags = flags & ~JS_PROP_ENUMERABLE;
         }
 
-        JSAtom prop = JS_NewAtom(context, prop_name);
+        JSAtom prop = JS_NewAtomLen(context, prop_name.data, prop_name.length);
 
         // Define property
         if (writable == JNI_FALSE) {
@@ -427,7 +480,7 @@ JSValue define_js_object(JNIEnv *env, JSContext *context,
 
         JS_FreeAtom(context, prop);
 
-        (*env)->ReleaseStringUTFChars(env, j_prop_name, prop_name);
+        jni_utf8_string_release(&prop_name);
         (*env)->DeleteLocalRef(env, j_prop_name);
         (*env)->DeleteLocalRef(env, element);
     }
@@ -435,21 +488,27 @@ JSValue define_js_object(JNIEnv *env, JSContext *context,
     // Add functions
     define_js_functions_on(env, context, globals, object, functions, common_func_data);
 
-    const char *c_name = (*env)->GetStringUTFChars(env, name, NULL);
+    JniUtf8String c_name;
+    if (!jni_string_to_utf8(env, name, &c_name)) {
+        JS_FreeValue(context, object);
+        return JS_EXCEPTION;
+    }
     JSValue retained_object = JS_DupValue(context, object);
     int define_result;
+    JSAtom object_name = JS_NewAtomLen(context, c_name.data, c_name.length);
 
     if (parent == NULL) {
         JSValue global_this = JS_GetGlobalObject(context);
         // Attach object to globalThis
-        define_result = JS_DefinePropertyValueStr(context, global_this, c_name, object, 0);
+        define_result = JS_DefinePropertyValue(context, global_this, object_name, object, 0);
         JS_FreeValue(context, global_this);
     } else {
         // Attach object to parent
-        define_result = JS_DefinePropertyValueStr(context, *parent, c_name, object, 0);
+        define_result = JS_DefinePropertyValue(context, *parent, object_name, object, 0);
     }
 
-    (*env)->ReleaseStringUTFChars(env, name, c_name);
+    JS_FreeAtom(context, object_name);
+    jni_utf8_string_release(&c_name);
 
     if (define_result < 0) {
         JS_FreeValue(context, retained_object);
@@ -467,14 +526,17 @@ void define_js_function(JNIEnv *env, JSContext *context,
     jobject global_host = (*env)->NewGlobalRef(env, host);
     cvector_push_back(globals->global_object_refs, global_host);
 
-    const char *func_name = (*env)->GetStringUTFChars(env, name, NULL);
+    JniUtf8String func_name;
+    if (!jni_string_to_utf8(env, name, &func_name)) {
+        return;
+    }
 
     // Function data
     uint32_t data_len = COMMON_FUNC_DATA_LEN + 1;
     JSValue func_data[3] = {
             JS_NewBigInt64(context, (int64_t) global_host), // host address
             JS_NewBigInt64(context, GLOBAL_THIS_HANDLE), // parent object handle
-            JS_NewString(context, func_name), // function name
+            JS_NewStringLen(context, func_name.data, func_name.length), // function name
     };
 
     for (uint32_t i = 0; i < data_len; i++) {
@@ -483,12 +545,14 @@ void define_js_function(JNIEnv *env, JSContext *context,
 
     JSValue global_this = JS_GetGlobalObject(context);
     if (is_async) {
-        define_async_js_function_on(context, globals, global_this, func_name,
-                                    data_len, func_data);
+        define_async_js_function_on(
+                context, globals, global_this, func_name.data, func_name.length,
+                data_len, func_data);
     } else {
-        define_js_function_on(context, global_this, func_name, data_len, func_data);
+        define_js_function_on(
+                context, global_this, func_name.data, func_name.length, data_len, func_data);
     }
     JS_FreeValue(context, global_this);
 
-    (*env)->ReleaseStringUTFChars(env, name, func_name);
+    jni_utf8_string_release(&func_name);
 }

--- a/quickjs/native/jni/exception_util.c
+++ b/quickjs/native/jni/exception_util.c
@@ -116,9 +116,18 @@ jthrowable new_js_error_exception(JNIEnv *env,
     jstring j_message = message != NULL
                         ? jni_string_from_utf8(env, message, message_length)
                         : NULL;
+    if (message != NULL && j_message == NULL) {
+        free(read_stack);
+        return NULL;
+    }
     jstring j_stack = js_stack != NULL
                       ? jni_string_from_utf8_c_string(env, js_stack)
                       : NULL;
+    if (js_stack != NULL && j_stack == NULL) {
+        delete_local_ref(env, j_message);
+        free(read_stack);
+        return NULL;
+    }
     free(read_stack);
 
     jthrowable exception = (*env)->NewObject(env, cls_quick_js_exception(env),

--- a/quickjs/native/jni/exception_util.c
+++ b/quickjs/native/jni/exception_util.c
@@ -4,6 +4,7 @@
 #include "jni_globals_generated.h"
 #include "log_util.h"
 #include "js_value_util.h"
+#include "jni_string_util.h"
 
 jthrowable new_qjs_exception(JNIEnv *env, const char *format, ...) {
     va_list args;
@@ -17,7 +18,11 @@ jthrowable new_qjs_exception(JNIEnv *env, const char *format, ...) {
     vsnprintf(result, length + 1, format, args);
     va_end(args);
 
-    jstring message = (*env)->NewStringUTF(env, result);
+    jstring message = jni_string_from_utf8(env, result, (size_t) length);
+    if (message == NULL) {
+        free(result);
+        return NULL;
+    }
     jthrowable exception = (*env)->NewObject(env, cls_quick_js_exception(env),
                                              method_quick_js_exception_init(env), message);
     (*env)->DeleteLocalRef(env, message);
@@ -42,8 +47,12 @@ jthrowable new_js_error_exception(JNIEnv *env,
     }
     const char *js_stack = stack != NULL ? stack : read_stack;
 
-    jstring j_message = message != NULL ? (*env)->NewStringUTF(env, message) : NULL;
-    jstring j_stack = js_stack != NULL ? (*env)->NewStringUTF(env, js_stack) : NULL;
+    jstring j_message = message != NULL
+                        ? jni_string_from_utf8_c_string(env, message)
+                        : NULL;
+    jstring j_stack = js_stack != NULL
+                      ? jni_string_from_utf8_c_string(env, js_stack)
+                      : NULL;
     free(read_stack);
 
     jthrowable exception = (*env)->NewObject(env, cls_quick_js_exception(env),
@@ -66,7 +75,19 @@ void jni_throw_qjs_exception(JNIEnv *env, const char *format, ...) {
     vsnprintf(result, length + 1, format, args);
     va_end(args);
 
-    (*env)->ThrowNew(env, cls_quick_js_exception(env), result);
+    jstring message = jni_string_from_utf8(env, result, (size_t) length);
+    if (message != NULL) {
+        jthrowable exception = (*env)->NewObject(
+                env,
+                cls_quick_js_exception(env),
+                method_quick_js_exception_init(env),
+                message);
+        if (exception != NULL) {
+            (*env)->Throw(env, exception);
+            (*env)->DeleteLocalRef(env, exception);
+        }
+        (*env)->DeleteLocalRef(env, message);
+    }
     free(result);
 }
 

--- a/quickjs/native/jni/exception_util.c
+++ b/quickjs/native/jni/exception_util.c
@@ -6,27 +6,92 @@
 #include "js_value_util.h"
 #include "jni_string_util.h"
 
-jthrowable new_qjs_exception(JNIEnv *env, const char *format, ...) {
-    va_list args;
-    va_start(args, format);
-    int length = vsnprintf(NULL, 0, format, args);
-    va_end(args);
+static const char formatting_failure_message[] = "Cannot format QuickJS exception message.";
 
-    char *result = (char *) malloc(length + 1);
-
-    va_start(args, format);
-    vsnprintf(result, length + 1, format, args);
-    va_end(args);
-
-    jstring message = jni_string_from_utf8(env, result, (size_t) length);
-    if (message == NULL) {
-        free(result);
+/** Creates a QuickJsException from an explicit-length UTF-8/WTF-8 message. */
+static jthrowable new_qjs_exception_from_utf8(JNIEnv *env,
+                                              const char *message,
+                                              size_t message_length) {
+    jstring java_message = jni_string_from_utf8(env, message, message_length);
+    if (java_message == NULL) {
         return NULL;
     }
     jthrowable exception = (*env)->NewObject(env, cls_quick_js_exception(env),
-                                             method_quick_js_exception_init(env), message);
-    (*env)->DeleteLocalRef(env, message);
-    free(result);
+                                             method_quick_js_exception_init(env),
+                                             java_message);
+    (*env)->DeleteLocalRef(env, java_message);
+    return exception;
+}
+
+/** Throws an explicit-length message and guarantees a fallback when JNI stays silent. */
+static void throw_qjs_exception_from_utf8(JNIEnv *env,
+                                          const char *message,
+                                          size_t message_length) {
+    jthrowable exception = new_qjs_exception_from_utf8(env, message, message_length);
+    if (exception != NULL) {
+        (*env)->Throw(env, exception);
+        (*env)->DeleteLocalRef(env, exception);
+    } else if (!(*env)->ExceptionCheck(env)) {
+        jclass exception_class = cls_quick_js_exception(env);
+        if (exception_class != NULL) {
+            (*env)->ThrowNew(env, exception_class, formatting_failure_message);
+        }
+    }
+}
+
+/** Formats a message into an owned buffer and rejects all formatting failures. */
+static int format_message(const char *format,
+                          va_list args,
+                          char **result,
+                          size_t *result_length) {
+    *result = NULL;
+    *result_length = 0;
+
+    va_list length_args;
+    va_copy(length_args, args);
+    int length = vsnprintf(NULL, 0, format, length_args);
+    va_end(length_args);
+    if (length < 0) {
+        return 0;
+    }
+
+    size_t capacity = (size_t) length + 1;
+    char *buffer = (char *) malloc(capacity);
+    if (buffer == NULL) {
+        return 0;
+    }
+
+    va_list write_args;
+    va_copy(write_args, args);
+    int written = vsnprintf(buffer, capacity, format, write_args);
+    va_end(write_args);
+    if (written != length) {
+        free(buffer);
+        return 0;
+    }
+
+    *result = buffer;
+    *result_length = (size_t) length;
+    return 1;
+}
+
+jthrowable new_qjs_exception(JNIEnv *env, const char *format, ...) {
+    char *message;
+    size_t message_length;
+    va_list args;
+    va_start(args, format);
+    int formatted = format_message(format, args, &message, &message_length);
+    va_end(args);
+
+    if (!formatted) {
+        return new_qjs_exception_from_utf8(
+                env,
+                formatting_failure_message,
+                sizeof(formatting_failure_message) - 1);
+    }
+
+    jthrowable exception = new_qjs_exception_from_utf8(env, message, message_length);
+    free(message);
     return exception;
 }
 
@@ -40,6 +105,7 @@ jthrowable new_js_error_exception(JNIEnv *env,
                                   JSContext *context,
                                   JSValue error,
                                   const char *message,
+                                  size_t message_length,
                                   const char *stack) {
     char *read_stack = NULL;
     if (stack == NULL) {
@@ -48,7 +114,7 @@ jthrowable new_js_error_exception(JNIEnv *env,
     const char *js_stack = stack != NULL ? stack : read_stack;
 
     jstring j_message = message != NULL
-                        ? jni_string_from_utf8_c_string(env, message)
+                        ? jni_string_from_utf8(env, message, message_length)
                         : NULL;
     jstring j_stack = js_stack != NULL
                       ? jni_string_from_utf8_c_string(env, js_stack)
@@ -64,31 +130,22 @@ jthrowable new_js_error_exception(JNIEnv *env,
 }
 
 void jni_throw_qjs_exception(JNIEnv *env, const char *format, ...) {
+    char *message;
+    size_t message_length;
     va_list args;
     va_start(args, format);
-    int length = vsnprintf(NULL, 0, format, args);
+    int formatted = format_message(format, args, &message, &message_length);
     va_end(args);
 
-    char *result = (char *) malloc(length + 1);
-
-    va_start(args, format);
-    vsnprintf(result, length + 1, format, args);
-    va_end(args);
-
-    jstring message = jni_string_from_utf8(env, result, (size_t) length);
-    if (message != NULL) {
-        jthrowable exception = (*env)->NewObject(
+    if (formatted) {
+        throw_qjs_exception_from_utf8(env, message, message_length);
+        free(message);
+    } else {
+        throw_qjs_exception_from_utf8(
                 env,
-                cls_quick_js_exception(env),
-                method_quick_js_exception_init(env),
-                message);
-        if (exception != NULL) {
-            (*env)->Throw(env, exception);
-            (*env)->DeleteLocalRef(env, exception);
-        }
-        (*env)->DeleteLocalRef(env, message);
+                formatting_failure_message,
+                sizeof(formatting_failure_message) - 1);
     }
-    free(result);
 }
 
 jthrowable try_catch_java_exceptions(JNIEnv *env) {
@@ -107,17 +164,32 @@ int check_js_context_exception(JNIEnv *env, JSContext *context) {
     // Check exception
     if (tag != JS_TAG_NULL && tag != JS_TAG_UNINITIALIZED) {
         char *message = NULL;
+        size_t message_length = 0;
         char *stack = NULL;
-        js_error_to_string(context, exception, &message, &stack);
+        js_error_to_string(context, exception, &message, &message_length, &stack);
         // Throw java exception
-        jthrowable java_exception = new_js_error_exception(env, context, exception, message,
-                                                          stack);
+        jthrowable java_exception = new_js_error_exception(
+                env,
+                context,
+                exception,
+                message,
+                message_length,
+                stack);
         JS_FreeValue(context, exception);
         if (java_exception != NULL) {
             (*env)->Throw(env, java_exception);
             (*env)->DeleteLocalRef(env, java_exception);
-        } else {
-            jni_throw_qjs_exception(env, "%s", message);
+        } else if (!(*env)->ExceptionCheck(env)) {
+            const char *fallback_message = message != NULL
+                                           ? message
+                                           : formatting_failure_message;
+            size_t fallback_message_length = message != NULL
+                                             ? message_length
+                                             : sizeof(formatting_failure_message) - 1;
+            throw_qjs_exception_from_utf8(
+                    env,
+                    fallback_message,
+                    fallback_message_length);
         }
         free(stack);
         free(message);

--- a/quickjs/native/jni/exception_util.h
+++ b/quickjs/native/jni/exception_util.h
@@ -12,6 +12,7 @@ jthrowable new_qjs_exception(JNIEnv *env, const char *format, ...);
  * error.
  *
  * @param message The already formatted message.
+ * @param message_length The message length in bytes, including embedded NUL bytes.
  * @param stack The stack trace of the error, pass NULL to read it from the
  * error, the caller keeps the ownership of it.
  */
@@ -19,6 +20,7 @@ jthrowable new_js_error_exception(JNIEnv *env,
                                   JSContext *context,
                                   JSValue error,
                                   const char *message,
+                                  size_t message_length,
                                   const char *stack);
 
 void jni_throw_qjs_exception(JNIEnv *env, const char *format, ...);

--- a/quickjs/native/jni/jni_string_util.c
+++ b/quickjs/native/jni/jni_string_util.c
@@ -1,0 +1,198 @@
+#include <limits.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include "jni_string_util.h"
+
+/** Raises OutOfMemoryError after a native allocation failure if no exception is pending. */
+static void throw_out_of_memory(JNIEnv *env) {
+    if ((*env)->ExceptionCheck(env)) {
+        return;
+    }
+    jclass error_class = (*env)->FindClass(env, "java/lang/OutOfMemoryError");
+    if (error_class != NULL) {
+        (*env)->ThrowNew(env, error_class, "Cannot allocate JNI string conversion buffer.");
+        (*env)->DeleteLocalRef(env, error_class);
+    }
+}
+
+/** Writes one Unicode code point as UTF-8/WTF-8, preserving surrogates as three bytes. */
+static size_t write_utf8(char *output, uint32_t code_point) {
+    if (code_point < 0x80) {
+        output[0] = (char) code_point;
+        return 1;
+    }
+    if (code_point < 0x800) {
+        output[0] = (char) (0xC0 | (code_point >> 6));
+        output[1] = (char) (0x80 | (code_point & 0x3F));
+        return 2;
+    }
+    if (code_point < 0x10000) {
+        output[0] = (char) (0xE0 | (code_point >> 12));
+        output[1] = (char) (0x80 | ((code_point >> 6) & 0x3F));
+        output[2] = (char) (0x80 | (code_point & 0x3F));
+        return 3;
+    }
+    output[0] = (char) (0xF0 | (code_point >> 18));
+    output[1] = (char) (0x80 | ((code_point >> 12) & 0x3F));
+    output[2] = (char) (0x80 | ((code_point >> 6) & 0x3F));
+    output[3] = (char) (0x80 | (code_point & 0x3F));
+    return 4;
+}
+
+int jni_string_to_utf8(JNIEnv *env, jstring value, JniUtf8String *result) {
+    if (result == NULL) {
+        return 0;
+    }
+    result->data = NULL;
+    result->length = 0;
+    if (value == NULL) {
+        return 0;
+    }
+
+    jsize utf16_length = (*env)->GetStringLength(env, value);
+    const jchar *utf16 = (*env)->GetStringChars(env, value, NULL);
+    if (utf16 == NULL) {
+        return 0;
+    }
+
+    if ((size_t) utf16_length > (SIZE_MAX - 1) / 3) {
+        (*env)->ReleaseStringChars(env, value, utf16);
+        throw_out_of_memory(env);
+        return 0;
+    }
+    size_t capacity = (size_t) utf16_length * 3 + 1;
+    char *utf8 = (char *) malloc(capacity);
+    if (utf8 == NULL) {
+        (*env)->ReleaseStringChars(env, value, utf16);
+        throw_out_of_memory(env);
+        return 0;
+    }
+
+    size_t output_length = 0;
+    for (jsize index = 0; index < utf16_length; index++) {
+        uint32_t code_point = utf16[index];
+        if (code_point >= 0xD800 && code_point <= 0xDBFF && index + 1 < utf16_length) {
+            uint32_t low = utf16[index + 1];
+            if (low >= 0xDC00 && low <= 0xDFFF) {
+                code_point = 0x10000 + ((code_point - 0xD800) << 10) + (low - 0xDC00);
+                index++;
+            }
+        }
+        output_length += write_utf8(utf8 + output_length, code_point);
+    }
+    utf8[output_length] = '\0';
+    (*env)->ReleaseStringChars(env, value, utf16);
+
+    result->data = utf8;
+    result->length = output_length;
+    return 1;
+}
+
+void jni_utf8_string_release(JniUtf8String *value) {
+    if (value == NULL) {
+        return;
+    }
+    free(value->data);
+    value->data = NULL;
+    value->length = 0;
+}
+
+/** Reads one strict UTF-8/WTF-8 code point, consuming one byte as U+FFFD on failure. */
+static uint32_t read_utf8(const uint8_t *input, size_t remaining, size_t *consumed) {
+    uint8_t first = input[0];
+    if (first < 0x80) {
+        *consumed = 1;
+        return first;
+    }
+
+    size_t length;
+    uint32_t code_point;
+    uint32_t minimum;
+    if (first >= 0xC2 && first <= 0xDF) {
+        length = 2;
+        code_point = first & 0x1F;
+        minimum = 0x80;
+    } else if (first >= 0xE0 && first <= 0xEF) {
+        length = 3;
+        code_point = first & 0x0F;
+        minimum = 0x800;
+    } else if (first >= 0xF0 && first <= 0xF4) {
+        length = 4;
+        code_point = first & 0x07;
+        minimum = 0x10000;
+    } else {
+        *consumed = 1;
+        return 0xFFFD;
+    }
+
+    if (remaining < length) {
+        *consumed = 1;
+        return 0xFFFD;
+    }
+    for (size_t index = 1; index < length; index++) {
+        uint8_t next = input[index];
+        if ((next & 0xC0) != 0x80) {
+            *consumed = 1;
+            return 0xFFFD;
+        }
+        code_point = (code_point << 6) | (next & 0x3F);
+    }
+    if (code_point < minimum || code_point > 0x10FFFF) {
+        *consumed = 1;
+        return 0xFFFD;
+    }
+
+    *consumed = length;
+    return code_point;
+}
+
+jstring jni_string_from_utf8(JNIEnv *env, const char *value, size_t length) {
+    if (value == NULL) {
+        return NULL;
+    }
+    if (length > INT_MAX) {
+        throw_out_of_memory(env);
+        return NULL;
+    }
+    if (length == 0) {
+        const jchar empty = 0;
+        return (*env)->NewString(env, &empty, 0);
+    }
+
+    if (length > SIZE_MAX / sizeof(jchar)) {
+        throw_out_of_memory(env);
+        return NULL;
+    }
+    jchar *utf16 = (jchar *) malloc(length * sizeof(jchar));
+    if (utf16 == NULL) {
+        throw_out_of_memory(env);
+        return NULL;
+    }
+
+    size_t input_index = 0;
+    jsize output_length = 0;
+    while (input_index < length) {
+        size_t consumed;
+        uint32_t code_point = read_utf8(
+                (const uint8_t *) value + input_index,
+                length - input_index,
+                &consumed);
+        input_index += consumed;
+        if (code_point <= 0xFFFF) {
+            utf16[output_length++] = (jchar) code_point;
+        } else {
+            code_point -= 0x10000;
+            utf16[output_length++] = (jchar) (0xD800 + (code_point >> 10));
+            utf16[output_length++] = (jchar) (0xDC00 + (code_point & 0x3FF));
+        }
+    }
+
+    jstring result = (*env)->NewString(env, utf16, output_length);
+    free(utf16);
+    return result;
+}
+
+jstring jni_string_from_utf8_c_string(JNIEnv *env, const char *value) {
+    return value != NULL ? jni_string_from_utf8(env, value, strlen(value)) : NULL;
+}

--- a/quickjs/native/jni/jni_string_util.h
+++ b/quickjs/native/jni/jni_string_util.h
@@ -1,0 +1,42 @@
+#ifndef QJS_KT_JNI_STRING_UTIL_H
+#define QJS_KT_JNI_STRING_UTIL_H
+
+#include <stddef.h>
+#include "jni.h"
+
+/**
+ * A UTF-8/WTF-8 buffer produced from a JNI string.
+ *
+ * data is allocated with malloc and NUL-terminated for convenience. The content
+ * itself may contain NUL, so callers must use length.
+ */
+typedef struct JniUtf8String {
+    char *data;
+    size_t length;
+} JniUtf8String;
+
+/**
+ * Converts a Java UTF-16 string to UTF-8/WTF-8 accepted by QuickJS.
+ *
+ * Valid surrogate pairs are encoded as standard UTF-8. Unpaired surrogates are
+ * preserved as WTF-8 to retain JavaScript UTF-16 code-unit semantics. Returns 1
+ * on success and 0 on failure while preserving or raising a JNI exception.
+ * Callers must release successful results with jni_utf8_string_release().
+ */
+int jni_string_to_utf8(JNIEnv *env, jstring value, JniUtf8String *result);
+
+/** Releases a buffer returned by jni_string_to_utf8() and clears the struct. */
+void jni_utf8_string_release(JniUtf8String *value);
+
+/**
+ * Converts length-delimited UTF-8/WTF-8 to a Java UTF-16 string.
+ *
+ * Supports supplementary characters, unpaired surrogates, and embedded NUL.
+ * Invalid UTF-8 bytes are replaced with U+FFFD.
+ */
+jstring jni_string_from_utf8(JNIEnv *env, const char *value, size_t length);
+
+/** Converts a NUL-terminated UTF-8/WTF-8 C string without embedded NUL. */
+jstring jni_string_from_utf8_c_string(JNIEnv *env, const char *value);
+
+#endif // QJS_KT_JNI_STRING_UTIL_H

--- a/quickjs/native/jni/js_value_util.c
+++ b/quickjs/native/jni/js_value_util.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 #include "js_value_util.h"
 #include "log_util.h"
@@ -65,7 +66,59 @@ char *js_array_join(JSContext *context, JSValue array, const char *separator) {
     return result;
 }
 
-void js_error_to_string(JSContext *context, JSValue error, char **out, char **out_stack) {
+char *js_error_message_join(const char *name,
+                            size_t name_length,
+                            const char *message,
+                            size_t message_length,
+                            const char *stack,
+                            int include_name,
+                            size_t *out_length) {
+    size_t stack_length = stack != NULL ? strlen(stack) : 0;
+    size_t length = message_length;
+    if (include_name) {
+        if (name_length > SIZE_MAX - 2 || name_length + 2 > SIZE_MAX - length) {
+            return NULL;
+        }
+        length += name_length + 2;
+    }
+    if (stack != NULL) {
+        if (length == SIZE_MAX || stack_length > SIZE_MAX - length - 1) {
+            return NULL;
+        }
+        length += stack_length + 1;
+    }
+
+    char *result = (char *) malloc(length + 1);
+    if (result == NULL) {
+        return NULL;
+    }
+
+    size_t position = 0;
+    if (include_name) {
+        memcpy(result + position, name, name_length);
+        position += name_length;
+        memcpy(result + position, ": ", 2);
+        position += 2;
+    }
+    memcpy(result + position, message, message_length);
+    position += message_length;
+    if (stack != NULL) {
+        result[position++] = '\n';
+        memcpy(result + position, stack, stack_length);
+        position += stack_length;
+    }
+    result[position] = '\0';
+    *out_length = length;
+    return result;
+}
+
+void js_error_to_string(JSContext *context,
+                        JSValue error,
+                        char **out,
+                        size_t *out_length,
+                        char **out_stack) {
+    *out = NULL;
+    *out_length = 0;
     if (out_stack != NULL) {
         *out_stack = NULL;
     }
@@ -75,11 +128,21 @@ void js_error_to_string(JSContext *context, JSValue error, char **out, char **ou
 
     if (JS_IsUndefined(js_name)) {
         // Could be arbitrary types
-        const char *c_str = JS_ToCString(context, error);
+        size_t c_str_length = 0;
+        const char *c_str = JS_ToCStringLen(context, &c_str_length, error);
         const char *str = c_str != NULL ? c_str : "<UNSUPPORTED_ERROR>";
-        char *copy = malloc(strlen(str) + 1);
-        strcpy(copy, str);
-        *out = copy;
+        size_t str_length = c_str != NULL
+                            ? c_str_length
+                            : sizeof("<UNSUPPORTED_ERROR>") - 1;
+        if (str_length < SIZE_MAX) {
+            char *copy = malloc(str_length + 1);
+            if (copy != NULL) {
+                memcpy(copy, str, str_length);
+                copy[str_length] = '\0';
+                *out = copy;
+                *out_length = str_length;
+            }
+        }
         if (c_str != NULL) {
             JS_FreeCString(context, c_str);
         }
@@ -87,29 +150,33 @@ void js_error_to_string(JSContext *context, JSValue error, char **out, char **ou
         return;
     }
 
-    const char *c_name = JS_ToCString(context, js_name);
+    size_t c_name_length = 0;
+    const char *c_name = JS_ToCStringLen(context, &c_name_length, js_name);
     const char *name = c_name != NULL ? c_name : "<UNKNOWN_ERROR>";
+    size_t name_length = c_name != NULL
+                         ? c_name_length
+                         : sizeof("<UNKNOWN_ERROR>") - 1;
 
     // Get message
     JSValue js_message = JS_GetPropertyStr(context, error, "message");
-    const char *c_message = JS_ToCString(context, js_message);
+    size_t c_message_length = 0;
+    const char *c_message = JS_ToCStringLen(context, &c_message_length, js_message);
     const char *message = c_message != NULL ? c_message : "<NO_MESSAGE>";
-
-    int name_len = strlen(name);
-    int msg_len = strlen(message);
+    size_t message_length = c_message != NULL
+                            ? c_message_length
+                            : sizeof("<NO_MESSAGE>") - 1;
 
     // Get stack trace
     char *stack = NULL;
     js_error_stack(context, error, &stack);
-    if (stack != NULL) {
-        char *full_message = (char *) malloc(name_len + msg_len + strlen(stack) + 4);
-        sprintf(full_message, "%s: %s\n%s", name, message, stack);
-        *out = full_message;
-    } else {
-        char *str = (char *) malloc(name_len + msg_len + 3);
-        sprintf(str, "%s: %s", name, message);
-        *out = str;
-    }
+    *out = js_error_message_join(
+            name,
+            name_length,
+            message,
+            message_length,
+            stack,
+            1,
+            out_length);
 
     // Hand the stack over to the caller, so it doesn't have to read it again
     if (out_stack != NULL) {

--- a/quickjs/native/jni/js_value_util.h
+++ b/quickjs/native/jni/js_value_util.h
@@ -11,15 +11,35 @@
 char *js_array_join(JSContext *context, JSValue array, const char *separator);
 
 /**
+ * Join an error name, message, and optional stack using explicit byte lengths.
+ *
+ * @param include_name Whether to prepend the name and a colon.
+ * @param out_length The resulting byte length, excluding the trailing NUL.
+ * @return An owned NUL-terminated buffer, or NULL if allocation fails.
+ */
+char *js_error_message_join(const char *name,
+                            size_t name_length,
+                            const char *message,
+                            size_t message_length,
+                            const char *stack,
+                            int include_name,
+                            size_t *out_length);
+
+/**
  * Join the js error message and stack trace (if any).
  *
  * @param context The js context.
  * @param error The error js value.
  * @param out Destination string pointer.
+ * @param out_length Destination for the message byte length.
  * @param out_stack Optional destination for the stack trace, pass NULL to
  * discard it, free() is required otherwise.
  */
-void js_error_to_string(JSContext *context, JSValue error, char **out, char **out_stack);
+void js_error_to_string(JSContext *context,
+                        JSValue error,
+                        char **out,
+                        size_t *out_length,
+                        char **out_stack);
 
 /**
  * Read the stack trace of a js error.

--- a/quickjs/native/jni/mapping/jobject_to_js_value.c
+++ b/quickjs/native/jni/mapping/jobject_to_js_value.c
@@ -1,11 +1,23 @@
 #include <string.h>
 #include <stdlib.h>
 #include "jobject_to_js_value.h"
+#include "jni_string_util.h"
 #include "js_value_util.h"
 #include "exception_util.h"
 #include "log_util.h"
 #include "jni_globals.h"
 #include "jni_globals_generated.h"
+
+/** Converts a Java string to a QuickJS string with the shared UTF-8/WTF-8 rules. */
+static JSValue java_string_to_js_string(JNIEnv *env, JSContext *context, jstring value) {
+    JniUtf8String utf8;
+    if (!jni_string_to_utf8(env, value, &utf8)) {
+        return JS_EXCEPTION;
+    }
+    JSValue result = JS_NewStringLen(context, utf8.data, utf8.length);
+    jni_utf8_string_release(&utf8);
+    return result;
+}
 
 void throw_circular_ref_error(JSContext *context) {
     const char *msg = "Unable to map objects with circular reference.";
@@ -282,23 +294,19 @@ JSValue java_throwable_to_js_error(JNIEnv *env, JSContext *context, jthrowable t
     // Get class js_name
     jstring j_cls_name = (jstring) (*env)->CallObjectMethod(env, exceptionClass,
                                                             method_class_get_name(env));
-    const char *cls_name = (*env)->GetStringUTFChars(env, j_cls_name, NULL);
-
     // Set error name
-    JSValue js_name = JS_NewString(context, cls_name);
+    JSValue js_name = java_string_to_js_string(env, context, j_cls_name);
     JS_SetPropertyStr(context, error, "name", js_name);
-
-    (*env)->ReleaseStringUTFChars(env, j_cls_name, cls_name);
+    (*env)->DeleteLocalRef(env, j_cls_name);
 
     // Get message
     jstring j_message = (jstring) (*env)->CallObjectMethod(env, throwable,
                                                            method_throwable_get_message(env));
     if (j_message != NULL) {
-        const char *message = (*env)->GetStringUTFChars(env, j_message, NULL);
         // Set message name
-        JSValue js_message = JS_NewString(context, message);
+        JSValue js_message = java_string_to_js_string(env, context, j_message);
         JS_SetPropertyStr(context, error, "message", js_message);
-        (*env)->ReleaseStringUTFChars(env, j_message, message);
+        (*env)->DeleteLocalRef(env, j_message);
     } else {
         JSValue js_message = JS_NewString(context, "");
         JS_SetPropertyStr(context, error, "message", js_message);
@@ -316,13 +324,11 @@ JSValue java_throwable_to_js_error(JNIEnv *env, JSContext *context, jthrowable t
     for (int i = 0; i < stack_trace_line_count; i++) {
         jobject element = (*env)->GetObjectArrayElement(env, j_stack_trace, i);
         jstring j_string = (jstring) (*env)->CallObjectMethod(env, element, to_string);
-        const char *line_string = (*env)->GetStringUTFChars(env, j_string, NULL);
 
         // Set stack trace line
-        JSValue line = JS_NewString(context, line_string);
+        JSValue line = java_string_to_js_string(env, context, j_string);
         JS_SetPropertyUint32(context, stack_trace, i, line);
 
-        (*env)->ReleaseStringUTFChars(env, j_string, line_string);
         (*env)->DeleteLocalRef(env, j_string);
         (*env)->DeleteLocalRef(env, element);
     }
@@ -386,14 +392,23 @@ JSValue java_map_to_js_object(JNIEnv *env, JSContext *context,
             JS_Throw(context, new_js_error(context, "TypeMappingError", message, 0, NULL));
             return JS_EXCEPTION;
         }
-        const char *str_key = (*env)->GetStringUTFChars(env, key, NULL);
+        JniUtf8String str_key;
+        if (!jni_string_to_utf8(env, (jstring) key, &str_key)) {
+            JS_FreeValue(context, js_object);
+            (*env)->DeleteLocalRef(env, entry);
+            (*env)->DeleteLocalRef(env, key);
+            if (delete_global_visited_ref) {
+                (*env)->DeleteGlobalRef(env, visited_set);
+            }
+            return JS_EXCEPTION;
+        }
 
         jobject value = (*env)->CallObjectMethod(env, entry, method_get_val);
 
         // Check circular refs
         if (visit_or_circular_ref_error(env, context, visited_set, value)) {
             JS_FreeValue(context, js_object);
-            (*env)->ReleaseStringUTFChars(env, key, str_key);
+            jni_utf8_string_release(&str_key);
             (*env)->DeleteLocalRef(env, entry);
             (*env)->DeleteLocalRef(env, key);
             (*env)->DeleteLocalRef(env, value);
@@ -403,11 +418,11 @@ JSValue java_map_to_js_object(JNIEnv *env, JSContext *context,
             return JS_EXCEPTION;
         }
 
-        JSAtom js_key = JS_NewAtom(context, str_key);
+        JSAtom js_key = JS_NewAtomLen(context, str_key.data, str_key.length);
         JSValue js_value = jobject_to_js_value(env, context, visited_set, value);
         if (JS_IsException(js_value)) {
             JS_FreeValue(context, js_object);
-            (*env)->ReleaseStringUTFChars(env, key, str_key);
+            jni_utf8_string_release(&str_key);
             (*env)->DeleteLocalRef(env, entry);
             (*env)->DeleteLocalRef(env, key);
             (*env)->DeleteLocalRef(env, value);
@@ -419,7 +434,7 @@ JSValue java_map_to_js_object(JNIEnv *env, JSContext *context,
         JS_SetProperty(context, js_object, js_key, js_value);
         JS_FreeAtom(context, js_key);
 
-        (*env)->ReleaseStringUTFChars(env, key, str_key);
+        jni_utf8_string_release(&str_key);
         (*env)->DeleteLocalRef(env, entry);
         (*env)->DeleteLocalRef(env, key);
         (*env)->DeleteLocalRef(env, value);
@@ -509,10 +524,7 @@ JSValue jobject_to_js_value(JNIEnv *env, JSContext *context, jobject visited_set
         result = JS_NewFloat64(context, unboxed);
     } else if ((*env)->IsInstanceOf(env, value, cls_string(env))) {
         // String
-        const char *c_str = (*env)->GetStringUTFChars(env, value, NULL);
-        JSValue js_value = JS_NewString(context, c_str);
-        (*env)->ReleaseStringUTFChars(env, value, c_str);
-        result = js_value;
+        result = java_string_to_js_string(env, context, (jstring) value);
     } else if ((*env)->IsInstanceOf(env, value, cls_list(env))) {
         // List
         result = java_list_to_js_array(env, context, visited_set, value);
@@ -539,14 +551,19 @@ JSValue jobject_to_js_value(JNIEnv *env, JSContext *context, jobject visited_set
 
     jclass cls = (*env)->GetObjectClass(env, value);
     jstring j_cls_name = (jstring) (*env)->CallObjectMethod(env, cls, method_class_get_name(env));
-    const char *cls_name = (*env)->GetStringUTFChars(env, j_cls_name, NULL);
+    JniUtf8String cls_name;
+    if (!jni_string_to_utf8(env, j_cls_name, &cls_name)) {
+        (*env)->DeleteLocalRef(env, j_cls_name);
+        (*env)->DeleteLocalRef(env, cls);
+        return JS_EXCEPTION;
+    }
 
     // Try by the class name
     if ((*env)->IsInstanceOf(env, value, cls_unit(env))) {
         result = JS_UNDEFINED;
-    } else if (strcmp("[B", cls_name) == 0) {
+    } else if (strcmp("[B", cls_name.data) == 0) {
         result = byte_array_to_js_int8array(env, context, value);
-    } else if (strcmp("[Z", cls_name) == 0) {
+    } else if (strcmp("[Z", cls_name.data) == 0) {
         // boolean array
         int size = (*env)->GetArrayLength(env, value);
         jboolean *arr = (*env)->GetBooleanArrayElements(env, value, NULL);
@@ -557,7 +574,7 @@ JSValue jobject_to_js_value(JNIEnv *env, JSContext *context, jobject visited_set
         }
         result = js_array;
         (*env)->ReleaseBooleanArrayElements(env, value, arr, 0);
-    } else if (strcmp("[I", cls_name) == 0) {
+    } else if (strcmp("[I", cls_name.data) == 0) {
         // int array
         int size = (*env)->GetArrayLength(env, value);
         jint *arr = (*env)->GetIntArrayElements(env, value, NULL);
@@ -568,7 +585,7 @@ JSValue jobject_to_js_value(JNIEnv *env, JSContext *context, jobject visited_set
         }
         result = js_array;
         (*env)->ReleaseIntArrayElements(env, value, arr, 0);
-    } else if (strcmp("[J", cls_name) == 0) {
+    } else if (strcmp("[J", cls_name.data) == 0) {
         // long array
         int size = (*env)->GetArrayLength(env, value);
         jlong *arr = (*env)->GetLongArrayElements(env, value, NULL);
@@ -579,7 +596,7 @@ JSValue jobject_to_js_value(JNIEnv *env, JSContext *context, jobject visited_set
         }
         result = js_array;
         (*env)->ReleaseLongArrayElements(env, value, arr, 0);
-    } else if (strcmp("[F", cls_name) == 0) {
+    } else if (strcmp("[F", cls_name.data) == 0) {
         // float array
         int size = (*env)->GetArrayLength(env, value);
         jfloat *arr = (*env)->GetFloatArrayElements(env, value, NULL);
@@ -590,7 +607,7 @@ JSValue jobject_to_js_value(JNIEnv *env, JSContext *context, jobject visited_set
         }
         result = js_array;
         (*env)->ReleaseFloatArrayElements(env, value, arr, 0);
-    } else if (strcmp("[D", cls_name) == 0) {
+    } else if (strcmp("[D", cls_name.data) == 0) {
         // double array
         int size = (*env)->GetArrayLength(env, value);
         jdouble *arr = (*env)->GetDoubleArrayElements(env, value, NULL);
@@ -601,7 +618,7 @@ JSValue jobject_to_js_value(JNIEnv *env, JSContext *context, jobject visited_set
         }
         result = js_array;
         (*env)->ReleaseDoubleArrayElements(env, value, arr, 0);
-    } else if ('[' == cls_name[0]) {
+    } else if ('[' == cls_name.data[0]) {
         // Object array
         int size = (*env)->GetArrayLength(env, value);
         JSValue js_array = JS_NewArray(context);
@@ -626,13 +643,13 @@ JSValue jobject_to_js_value(JNIEnv *env, JSContext *context, jobject visited_set
             result = js_array;
         }
     } else {
-        char message[100];
-        sprintf(message, "Cannot convert java type '%s' to a js value.", cls_name);
-        JS_Throw(context, new_js_error(context, "TypeError", message, 0, NULL));
+        JS_ThrowTypeError(context, "Cannot convert java type '%s' to a js value.", cls_name.data);
         result = JS_EXCEPTION;
     }
 
-    (*env)->ReleaseStringUTFChars(env, j_cls_name, cls_name);
+    jni_utf8_string_release(&cls_name);
+    (*env)->DeleteLocalRef(env, j_cls_name);
+    (*env)->DeleteLocalRef(env, cls);
 
     return result;
 }

--- a/quickjs/native/jni/mapping/js_value_to_jobject.c
+++ b/quickjs/native/jni/mapping/js_value_to_jobject.c
@@ -334,6 +334,19 @@ jobject object_to_java_js_object(JNIEnv *env, JSContext *context, JSValue value)
             }
         }
 
+        if (java_val == NULL && (*env)->ExceptionCheck(env)) {
+            (*env)->DeleteLocalRef(env, java_key);
+            JS_FreeValue(context, key);
+            JS_FreeValue(context, val);
+            JS_FreeAtom(context, prop_atom);
+            for (uint32_t remaining = i + 1; remaining < prop_len; remaining++) {
+                JS_FreeAtom(context, props[remaining].atom);
+            }
+            js_free(context, props);
+            (*env)->DeleteLocalRef(env, java_map);
+            return NULL;
+        }
+
         // Map.put(k, v)
         (*env)->CallObjectMethod(env, java_map, put_method, java_key, java_val);
 

--- a/quickjs/native/jni/mapping/js_value_to_jobject.c
+++ b/quickjs/native/jni/mapping/js_value_to_jobject.c
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include "js_value_to_jobject.h"
 #include "js_value_util.h"
@@ -41,86 +42,106 @@ jthrowable js_error_to_java_error(JNIEnv *env, JSContext *context, JSValue error
         return java_error;
     }
 
-    const char *original_name = JS_ToCString(context, js_name);
+    size_t original_name_length = 0;
+    const char *original_name = JS_ToCStringLen(context, &original_name_length, js_name);
     const char *name = original_name != NULL ? original_name : "<UNKNOWN_ERROR>";
+    size_t name_length = original_name != NULL
+                         ? original_name_length
+                         : sizeof("<UNKNOWN_ERROR>") - 1;
 
     jclass java_error_cls = NULL;
-    if (original_name != NULL) {
-        char *maybe_cls_name = malloc(strlen(original_name) + 1);
-        strcpy(maybe_cls_name, original_name);
-        replace_dots_with_slashes(maybe_cls_name);
-        java_error_cls = (*env)->FindClass(env, maybe_cls_name);
-        jthrowable exception = try_catch_java_exceptions(env);
-        if (exception != NULL) {
-            java_error_cls = NULL;
+    if (original_name != NULL &&
+        memchr(original_name, '\0', original_name_length) == NULL &&
+        original_name_length < SIZE_MAX) {
+        char *maybe_cls_name = malloc(original_name_length + 1);
+        if (maybe_cls_name != NULL) {
+            memcpy(maybe_cls_name, original_name, original_name_length);
+            maybe_cls_name[original_name_length] = '\0';
+            replace_dots_with_slashes(maybe_cls_name);
+            java_error_cls = (*env)->FindClass(env, maybe_cls_name);
+            jthrowable exception = try_catch_java_exceptions(env);
+            if (exception != NULL) {
+                java_error_cls = NULL;
+                (*env)->DeleteLocalRef(env, exception);
+            }
+            free(maybe_cls_name);
         }
-        free(maybe_cls_name);
     }
 
     // Get message
     JSValue js_message = JS_GetPropertyStr(context, error, "message");
-    const char *original_message = JS_ToCString(context, js_message);
+    size_t original_message_length = 0;
+    const char *original_message = JS_ToCStringLen(
+            context,
+            &original_message_length,
+            js_message);
     const char *message = original_message != NULL ? original_message : "<NO_MESSAGE>";
-
-    int name_len = strlen(name);
-    int msg_len = strlen(message);
+    size_t message_length = original_message != NULL
+                            ? original_message_length
+                            : sizeof("<NO_MESSAGE>") - 1;
 
     // Get stack trace
     char *stack = NULL;
     js_error_stack(context, error, &stack);
-
-    char *full_message;
-    if (stack != NULL) {
-        // Join
-        if (java_error_cls == NULL) {
-            // Add error name to the message
-            full_message = (char *) malloc(name_len + msg_len + strlen(stack) + 4);
-            sprintf(full_message, "%s: %s\n%s", name, message, stack);
-        } else {
-            full_message = (char *) malloc(msg_len + strlen(stack) + 2);
-            sprintf(full_message, "%s\n%s", message, stack);
-        }
-    } else {
-        if (java_error_cls == NULL) {
-            full_message = malloc(name_len + msg_len + 3);
-            sprintf(full_message, "%s: %s", name, message);
-        } else {
-            full_message = malloc(msg_len + 1);
-            strcpy(full_message, message);
-        }
-    }
-
-    if (original_name != NULL) {
-        JS_FreeCString(context, original_name);
-    }
-    JS_FreeValue(context, js_name);
 
     if (java_error_cls != NULL) {
         jmethodID constructor = (*env)->GetMethodID(env, java_error_cls, "<init>",
                                                     "(Ljava/lang/String;)V");
         jthrowable e = try_catch_java_exceptions(env);
         if (e == NULL && constructor != NULL) {
-            jstring java_message = jni_string_from_utf8_c_string(env, message);
+            jstring java_message = jni_string_from_utf8(env, message, message_length);
             jthrowable java_error = (*env)->NewObject(env, java_error_cls, constructor,
                                                       java_message);
             (*env)->DeleteLocalRef(env, java_message);
             if (original_message != NULL) {
                 JS_FreeCString(context, original_message);
             }
+            if (original_name != NULL) {
+                JS_FreeCString(context, original_name);
+            }
+            JS_FreeValue(context, js_name);
             JS_FreeValue(context, js_message);
-            free(full_message);
+            (*env)->DeleteLocalRef(env, java_error_cls);
             free(stack);
             return java_error;
+        } else if (e != NULL) {
+            (*env)->DeleteLocalRef(env, e);
         }
     }
 
+    size_t full_message_length = 0;
+    char *full_message = js_error_message_join(
+            name,
+            name_length,
+            message,
+            message_length,
+            stack,
+            java_error_cls == NULL,
+            &full_message_length);
+
+    // Fallback to the default error class
+    const char *fallback_message = full_message != NULL ? full_message : message;
+    size_t fallback_message_length = full_message != NULL
+                                     ? full_message_length
+                                     : message_length;
+    jthrowable java_error = new_js_error_exception(
+            env,
+            context,
+            error,
+            fallback_message,
+            fallback_message_length,
+            stack);
     if (original_message != NULL) {
         JS_FreeCString(context, original_message);
     }
+    if (original_name != NULL) {
+        JS_FreeCString(context, original_name);
+    }
+    JS_FreeValue(context, js_name);
     JS_FreeValue(context, js_message);
-
-    // Fallback to the default error class
-    jthrowable java_error = new_js_error_exception(env, context, error, full_message, stack);
+    if (java_error_cls != NULL) {
+        (*env)->DeleteLocalRef(env, java_error_cls);
+    }
     free(full_message);
     free(stack);
     return java_error;

--- a/quickjs/native/jni/mapping/js_value_to_jobject.c
+++ b/quickjs/native/jni/mapping/js_value_to_jobject.c
@@ -90,6 +90,19 @@ jthrowable js_error_to_java_error(JNIEnv *env, JSContext *context, JSValue error
         jthrowable e = try_catch_java_exceptions(env);
         if (e == NULL && constructor != NULL) {
             jstring java_message = jni_string_from_utf8(env, message, message_length);
+            if (java_message == NULL) {
+                if (original_message != NULL) {
+                    JS_FreeCString(context, original_message);
+                }
+                if (original_name != NULL) {
+                    JS_FreeCString(context, original_name);
+                }
+                JS_FreeValue(context, js_name);
+                JS_FreeValue(context, js_message);
+                (*env)->DeleteLocalRef(env, java_error_cls);
+                free(stack);
+                return NULL;
+            }
             jthrowable java_error = (*env)->NewObject(env, java_error_cls, constructor,
                                                       java_message);
             (*env)->DeleteLocalRef(env, java_message);
@@ -256,7 +269,11 @@ jobject object_to_java_js_object(JNIEnv *env, JSContext *context, JSValue value)
     if (JS_IsException(json)) {
         JSValue js_err = JS_GetException(context);
         if (!JS_IsNull(js_err)) {
-            (*env)->Throw(env, js_error_to_java_error(env, context, js_err));
+            jthrowable java_error = js_error_to_java_error(env, context, js_err);
+            if (java_error != NULL) {
+                (*env)->Throw(env, java_error);
+                (*env)->DeleteLocalRef(env, java_error);
+            }
         }
         JS_FreeValue(context, js_err);
         JS_FreeValue(context, json);
@@ -384,7 +401,10 @@ jobject js_value_to_jobject(JNIEnv *env, JSContext *context, JSValue value) {
         JSValue exception = JS_GetException(context);
         jobject java_error = js_error_to_java_error(env, context, exception);
         JS_FreeValue(context, exception);
-        (*env)->Throw(env, java_error);
+        if (java_error != NULL) {
+            (*env)->Throw(env, java_error);
+            (*env)->DeleteLocalRef(env, java_error);
+        }
         return NULL;
     }
 

--- a/quickjs/native/jni/mapping/js_value_to_jobject.c
+++ b/quickjs/native/jni/mapping/js_value_to_jobject.c
@@ -6,9 +6,11 @@
 #include "exception_util.h"
 #include "log_util.h"
 #include "jni_types_util.h"
+#include "jni_string_util.h"
 
-jobject to_java_string(JNIEnv *env, const char *str) {
-    return str != NULL ? (*env)->NewStringUTF(env, str) : NULL;
+/** Creates a Java string with the shared UTF-8/WTF-8 decoding rules. */
+static jobject to_java_string(JNIEnv *env, const char *str, size_t length) {
+    return str != NULL ? jni_string_from_utf8(env, str, length) : NULL;
 }
 
 void replace_dots_with_slashes(char *str) {
@@ -98,7 +100,7 @@ jthrowable js_error_to_java_error(JNIEnv *env, JSContext *context, JSValue error
                                                     "(Ljava/lang/String;)V");
         jthrowable e = try_catch_java_exceptions(env);
         if (e == NULL && constructor != NULL) {
-            jstring java_message = (*env)->NewStringUTF(env, message);
+            jstring java_message = jni_string_from_utf8_c_string(env, message);
             jthrowable java_error = (*env)->NewObject(env, java_error_cls, constructor,
                                                       java_message);
             (*env)->DeleteLocalRef(env, java_message);
@@ -278,11 +280,15 @@ jobject object_to_java_js_object(JNIEnv *env, JSContext *context, JSValue value)
         if (JS_VALUE_GET_TAG(val) == value_tag &&
             JS_VALUE_GET_PTR(val) == value_ptr) {
             // Avoid infinite recursion
-            const char *val_str = JS_ToCString(context, val);
-            java_val = to_java_string(env, val_str);
-            JS_FreeCString(context, val_str);
+            size_t val_length = 0;
+            const char *val_str = JS_ToCStringLen(context, &val_length, val);
+            java_val = to_java_string(env, val_str, val_length);
+            if (val_str != NULL) {
+                JS_FreeCString(context, val_str);
+            }
         } else if (JS_IsFunction(context, val)) {
-            java_val = to_java_string(env, "[Function]");
+            const char *function_label = "[Function]";
+            java_val = to_java_string(env, function_label, strlen(function_label));
         } else {
             java_val = js_value_to_jobject(env, context, val);
             if (try_catch_java_exceptions(env) != NULL) {
@@ -383,9 +389,12 @@ jobject js_value_to_jobject(JNIEnv *env, JSContext *context, JSValue value) {
     }
 
     if (JS_IsString(value)) {
-        const char *str = JS_ToCString(context, value);
-        jobject result = to_java_string(env, str);
-        JS_FreeCString(context, str);
+        size_t length = 0;
+        const char *str = JS_ToCStringLen(context, &length, value);
+        jobject result = to_java_string(env, str, length);
+        if (str != NULL) {
+            JS_FreeCString(context, str);
+        }
         return result;
     }
 

--- a/quickjs/native/jni/module_loader.c
+++ b/quickjs/native/jni/module_loader.c
@@ -4,6 +4,7 @@
 #include "mapping/jobject_to_js_value.h"
 #include "exception_util.h"
 #include "jni_globals.h"
+#include "jni_string_util.h"
 
 /**
  * Converts a pending Java callback failure to a JavaScript error so it follows
@@ -181,7 +182,7 @@ static char *normalize_module(JSContext *context,
         return NULL;
     }
 
-    jstring java_base_name = (*env)->NewStringUTF(env, base_name);
+    jstring java_base_name = jni_string_from_utf8_c_string(env, base_name);
     if (java_base_name == NULL) {
         if (!forward_java_exception(
                 env, context,
@@ -191,7 +192,7 @@ static char *normalize_module(JSContext *context,
         }
         return NULL;
     }
-    jstring java_requested_name = (*env)->NewStringUTF(env, requested_name);
+    jstring java_requested_name = jni_string_from_utf8_c_string(env, requested_name);
     if (java_requested_name == NULL) {
         if (!forward_java_exception(
                 env, context,
@@ -222,8 +223,8 @@ static char *normalize_module(JSContext *context,
         return NULL;
     }
 
-    const char *normalized_name = (*env)->GetStringUTFChars(env, java_normalized_name, NULL);
-    if (normalized_name == NULL) {
+    JniUtf8String normalized_name;
+    if (!jni_string_to_utf8(env, java_normalized_name, &normalized_name)) {
         if (!forward_java_exception(
                 env, context,
                 "Cannot read normalized module name for '%s'.", requested_name)) {
@@ -233,12 +234,18 @@ static char *normalize_module(JSContext *context,
         (*env)->DeleteLocalRef(env, java_normalized_name);
         return NULL;
     }
-    size_t normalized_length = strlen(normalized_name);
-    char *result = js_malloc(context, normalized_length + 1);
-    if (result != NULL) {
-        memcpy(result, normalized_name, normalized_length + 1);
+    // The QuickJS module-loader ABI uses C strings and cannot represent NUL in module names.
+    if (memchr(normalized_name.data, '\0', normalized_name.length) != NULL) {
+        JS_ThrowTypeError(context, "Normalized module name cannot contain NUL.");
+        jni_utf8_string_release(&normalized_name);
+        (*env)->DeleteLocalRef(env, java_normalized_name);
+        return NULL;
     }
-    (*env)->ReleaseStringUTFChars(env, java_normalized_name, normalized_name);
+    char *result = js_malloc(context, normalized_name.length + 1);
+    if (result != NULL) {
+        memcpy(result, normalized_name.data, normalized_name.length + 1);
+    }
+    jni_utf8_string_release(&normalized_name);
     (*env)->DeleteLocalRef(env, java_normalized_name);
     return result;
 }
@@ -255,7 +262,7 @@ static JSModuleDef *load_module(JSContext *context, const char *module_name, voi
         return NULL;
     }
 
-    jstring java_name = (*env)->NewStringUTF(env, module_name);
+    jstring java_name = jni_string_from_utf8_c_string(env, module_name);
     if (java_name == NULL) {
         if (!forward_java_exception(
                 env, context,
@@ -295,8 +302,8 @@ static JSModuleDef *load_module(JSContext *context, const char *module_name, voi
 
     JSValue module = JS_UNDEFINED;
     if (java_source != NULL) {
-        const char *source = (*env)->GetStringUTFChars(env, java_source, NULL);
-        if (source == NULL) {
+        JniUtf8String source;
+        if (!jni_string_to_utf8(env, java_source, &source)) {
             if (!forward_java_exception(
                     env, context,
                     "Cannot read module source '%s'.", module_name)) {
@@ -307,11 +314,11 @@ static JSModuleDef *load_module(JSContext *context, const char *module_name, voi
         }
         module = JS_Eval(
                 context,
-                source,
-                strlen(source),
+                source.data,
+                source.length,
                 module_name,
                 JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY);
-        (*env)->ReleaseStringUTFChars(env, java_source, source);
+        jni_utf8_string_release(&source);
         (*env)->DeleteLocalRef(env, java_source);
         if (!JS_IsException(module) && JS_VALUE_GET_TAG(module) == JS_TAG_MODULE &&
             !notify_module_compiled(

--- a/quickjs/native/jni/quickjs_jni.c
+++ b/quickjs/native/jni/quickjs_jni.c
@@ -14,6 +14,7 @@
 #include "quickjs_interrupt.h"
 #include "promise_rejection_handler.h"
 #include "module_loader.h"
+#include "jni_string_util.h"
 
 JSRuntime *runtime_from_ptr(JNIEnv *env, jlong ptr) {
     if (ptr == 0) {
@@ -605,25 +606,34 @@ jobject eval(JNIEnv *env, jlong context_ptr,
              jstring jfilename,
              jstring jcode,
              int eval_flags) {
-    const char *filename = (*env)->GetStringUTFChars(env, jfilename, NULL);
-    if (filename == NULL) {
-        jni_throw_qjs_exception(env, "Cannot read filename.");
+    JniUtf8String filename;
+    if (!jni_string_to_utf8(env, jfilename, &filename)) {
+        if (!(*env)->ExceptionCheck(env)) {
+            jni_throw_qjs_exception(env, "Cannot read filename.");
+        }
         return NULL;
     }
 
-    const char *code = (*env)->GetStringUTFChars(env, jcode, NULL);
-    if (code == NULL) {
-        jni_throw_qjs_exception(env, "Cannot read code.");
+    JniUtf8String code;
+    if (!jni_string_to_utf8(env, jcode, &code)) {
+        jni_utf8_string_release(&filename);
+        if (!(*env)->ExceptionCheck(env)) {
+            jni_throw_qjs_exception(env, "Cannot read code.");
+        }
         return NULL;
     }
 
     JSContext *context = context_from_ptr(env, context_ptr);
     if (context == NULL) {
+        jni_utf8_string_release(&code);
+        jni_utf8_string_release(&filename);
         return NULL;
     }
 
     Globals *globals = globals_from_ptr(env, globals_ptr);
     if (globals == NULL) {
+        jni_utf8_string_release(&code);
+        jni_utf8_string_release(&filename);
         return NULL;
     }
 
@@ -635,11 +645,16 @@ jobject eval(JNIEnv *env, jlong context_ptr,
     JS_UpdateStackTop(JS_GetRuntime(context));
 
     // Run code
-    JSValue value = JS_Eval(context, code, strlen(code), filename, eval_flags);
+    JSValue value = JS_Eval(
+            context,
+            code.data,
+            code.length,
+            filename.data,
+            eval_flags);
 
-    // Free strings
-    (*env)->ReleaseStringUTFChars(env, jfilename, filename);
-    (*env)->ReleaseStringUTFChars(env, jcode, code);
+    // QuickJS does not retain these conversion buffers after JS_Eval returns.
+    jni_utf8_string_release(&code);
+    jni_utf8_string_release(&filename);
 
     int async = (eval_flags & JS_EVAL_FLAG_ASYNC) != 0;
 
@@ -741,7 +756,7 @@ Java_com_dokar_quickjs_QuickJs_resolveModuleGraphBytecode(JNIEnv *env,
         return NULL;
     }
 
-    jstring result = (*env)->NewStringUTF(env, module_name);
+    jstring result = jni_string_from_utf8_c_string(env, module_name);
     JS_FreeCString(context, module_name);
     if (result == NULL) {
         JS_FreeValue(context, entry);
@@ -780,32 +795,41 @@ Java_com_dokar_quickjs_QuickJs_evaluate(JNIEnv *env,
                                         jboolean as_module) {
     int eval_flags = JS_EVAL_FLAG_ASYNC;
     eval_flags |= as_module ? JS_EVAL_TYPE_MODULE : JS_EVAL_TYPE_GLOBAL;
-    const char *filename = (*env)->GetStringUTFChars(env, jfilename, NULL);
-    if (filename == NULL) {
-        jni_throw_qjs_exception(env, "Cannot read filename.");
+    JniUtf8String filename;
+    if (!jni_string_to_utf8(env, jfilename, &filename)) {
+        if (!(*env)->ExceptionCheck(env)) {
+            jni_throw_qjs_exception(env, "Cannot read filename.");
+        }
         return -1;
     }
-    const char *code = (*env)->GetStringUTFChars(env, jcode, NULL);
-    if (code == NULL) {
-        (*env)->ReleaseStringUTFChars(env, jfilename, filename);
-        jni_throw_qjs_exception(env, "Cannot read code.");
+    JniUtf8String code;
+    if (!jni_string_to_utf8(env, jcode, &code)) {
+        jni_utf8_string_release(&filename);
+        if (!(*env)->ExceptionCheck(env)) {
+            jni_throw_qjs_exception(env, "Cannot read code.");
+        }
         return -1;
     }
     JSContext *context = context_from_ptr(env, context_ptr);
     Globals *globals = globals_from_ptr(env, globals_ptr);
     if (context == NULL || globals == NULL) {
-        (*env)->ReleaseStringUTFChars(env, jfilename, filename);
-        (*env)->ReleaseStringUTFChars(env, jcode, code);
+        jni_utf8_string_release(&code);
+        jni_utf8_string_release(&filename);
         return -1;
     }
 
     pthread_mutex_lock(&globals->js_mutex);
     JS_UpdateStackTop(JS_GetRuntime(context));
-    JSValue value = JS_Eval(context, code, strlen(code), filename, eval_flags);
+    JSValue value = JS_Eval(
+            context,
+            code.data,
+            code.length,
+            filename.data,
+            eval_flags);
     pthread_mutex_unlock(&globals->js_mutex);
 
-    (*env)->ReleaseStringUTFChars(env, jfilename, filename);
-    (*env)->ReleaseStringUTFChars(env, jcode, code);
+    jni_utf8_string_release(&code);
+    jni_utf8_string_release(&filename);
     return store_evaluate_result(env, context, globals, value);
 }
 

--- a/quickjs/src/commonTest/kotlin/com/dokar/quickjs/test/UnicodeStringTest.kt
+++ b/quickjs/src/commonTest/kotlin/com/dokar/quickjs/test/UnicodeStringTest.kt
@@ -1,0 +1,118 @@
+package com.dokar.quickjs.test
+
+import com.dokar.quickjs.ModuleContent
+import com.dokar.quickjs.QuickJsException
+import com.dokar.quickjs.binding.define
+import com.dokar.quickjs.binding.function
+import com.dokar.quickjs.binding.toJsObject
+import com.dokar.quickjs.moduleLoader
+import com.dokar.quickjs.quickJs
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * Verifies that valid Unicode survives every bridge path between Kotlin and QuickJS.
+ */
+class UnicodeStringTest {
+    private val unicodeText = "ASCII 中文 e\u0301 😀 👩‍💻"
+
+    /** Verifies source, result, supplementary-plane identifiers, and bytecode. */
+    @Test
+    fun evaluateAndBytecodePreserveUnicode() = runTest {
+        quickJs {
+            assertEquals(unicodeText, evaluate<String>("'$unicodeText'"))
+            assertEquals(42, evaluate<Int>("const 𐐀 = 42; 𐐀"))
+
+            val bytecode = compile("'$unicodeText'")
+            assertEquals(unicodeText, evaluate<String>(bytecode))
+        }
+    }
+
+    /** Verifies binding names, property names, arguments, results, and nested object keys. */
+    @Test
+    fun bindingsAndObjectsPreserveUnicode() = runTest {
+        quickJs {
+            function("函数😀") { args -> args.single() }
+            define("对象😀") {
+                property("属性😀") {
+                    getter { unicodeText }
+                }
+                function("回声😀") { args -> args.single() }
+            }
+            function("返回对象😀") {
+                mapOf("键😀" to unicodeText).toJsObject()
+            }
+
+            assertEquals(
+                unicodeText,
+                evaluate<String>("globalThis['函数😀']('$unicodeText')"),
+            )
+            assertEquals(
+                unicodeText,
+                evaluate<String>("globalThis['对象😀']['属性😀']"),
+            )
+            assertEquals(
+                unicodeText,
+                evaluate<String>("globalThis['对象😀']['回声😀']('$unicodeText')"),
+            )
+            val result = evaluate<Map<String, Any?>>("globalThis['返回对象😀']()")
+            assertEquals(unicodeText, result["键😀"])
+        }
+    }
+
+    /** Verifies Unicode propagation in JavaScript and Kotlin exception messages. */
+    @Test
+    fun exceptionsPreserveUnicode() = runTest {
+        quickJs {
+            val jsError = assertFailsWith<QuickJsException> {
+                evaluate<Any?>("throw new Error('$unicodeText')")
+            }
+            assertContains(jsError.message.orEmpty(), unicodeText)
+
+            function("抛出😀") { error(unicodeText) }
+            val kotlinError = assertFailsWith<IllegalStateException> {
+                evaluate<Any?>("globalThis['抛出😀']()")
+            }
+            assertEquals(unicodeText, kotlinError.message)
+        }
+    }
+
+    /** Verifies Unicode in module names, module source, and compilation callbacks. */
+    @Test
+    fun moduleLoaderPreservesUnicode() = runTest {
+        val moduleName = "模块😀"
+        val loaded = mutableListOf<String>()
+        val compiled = mutableListOf<String>()
+        val loader = moduleLoader {
+            load { name ->
+                loaded += name
+                if (name == moduleName) {
+                    ModuleContent.Source("export const value = '$unicodeText';")
+                } else {
+                    null
+                }
+            }
+            onCompiled { name, _ -> compiled += name }
+        }
+
+        var result: String? = null
+        quickJs(moduleLoader = loader) {
+            function("捕获😀") { args -> result = args.single() as String }
+            evaluate<Any?>(
+                code = """
+                    import { value } from '$moduleName';
+                    globalThis['捕获😀'](value);
+                """.trimIndent(),
+                filename = "入口😀",
+                asModule = true,
+            )
+        }
+
+        assertEquals(unicodeText, result)
+        assertEquals(listOf(moduleName), loaded)
+        assertEquals(listOf(moduleName), compiled)
+    }
+}

--- a/quickjs/src/jniTest/kotlin/com/dokar/quickjs/test/JniUnicodeStringTest.kt
+++ b/quickjs/src/jniTest/kotlin/com/dokar/quickjs/test/JniUnicodeStringTest.kt
@@ -1,10 +1,14 @@
 package com.dokar.quickjs.test
 
+import com.dokar.quickjs.QuickJsException
 import com.dokar.quickjs.binding.function
 import com.dokar.quickjs.quickJs
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
 
 /**
  * Verifies code-unit-preserving round trips for UTF-16 edge cases in the JVM JNI bridge.
@@ -20,6 +24,23 @@ class JniUnicodeStringTest {
             assertEquals(text, evaluate<String>("returnNull()"))
             assertEquals(text, evaluate<String>("'before\\u0000after'"))
             assertEquals(text.length, evaluate<Int>("returnNull().length"))
+        }
+    }
+
+    /** Verifies that JavaScript error mapping preserves embedded NUL. */
+    @Test
+    fun embeddedNullInErrorMessageIsPreserved() = runTest {
+        val text = "before\u0000after"
+        quickJs {
+            val error = assertIs<QuickJsException>(
+                evaluate<Any?>("new Error('before\\u0000after')"),
+            )
+            assertContains(error.message.orEmpty(), text)
+
+            val thrown = assertFailsWith<QuickJsException> {
+                evaluate<Any?>("throw new Error('before\\u0000after')")
+            }
+            assertContains(thrown.message.orEmpty(), text)
         }
     }
 

--- a/quickjs/src/jniTest/kotlin/com/dokar/quickjs/test/JniUnicodeStringTest.kt
+++ b/quickjs/src/jniTest/kotlin/com/dokar/quickjs/test/JniUnicodeStringTest.kt
@@ -1,0 +1,42 @@
+package com.dokar.quickjs.test
+
+import com.dokar.quickjs.binding.function
+import com.dokar.quickjs.quickJs
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Verifies code-unit-preserving round trips for UTF-16 edge cases in the JVM JNI bridge.
+ */
+class JniUnicodeStringTest {
+    /** Verifies that embedded NUL is not truncated by C-string handling. */
+    @Test
+    fun embeddedNullRoundTrips() = runTest {
+        val text = "before\u0000after"
+        quickJs {
+            function("returnNull") { text }
+
+            assertEquals(text, evaluate<String>("returnNull()"))
+            assertEquals(text, evaluate<String>("'before\\u0000after'"))
+            assertEquals(text.length, evaluate<Int>("returnNull().length"))
+        }
+    }
+
+    /** Verifies that WTF-8 preserves unpaired UTF-16 surrogate code units. */
+    @Test
+    fun unpairedSurrogatesRoundTrip() = runTest {
+        val highSurrogate = charArrayOf('\uD83D').concatToString()
+        val lowSurrogate = charArrayOf('\uDE00').concatToString()
+
+        quickJs {
+            function("returnHigh") { highSurrogate }
+            function("returnLow") { lowSurrogate }
+
+            assertEquals(highSurrogate, evaluate<String>("returnHigh()"))
+            assertEquals(lowSurrogate, evaluate<String>("returnLow()"))
+            assertEquals(highSurrogate, evaluate<String>("'\\uD83D'"))
+            assertEquals(lowSurrogate, evaluate<String>("'\\uDE00'"))
+        }
+    }
+}


### PR DESCRIPTION
### Background

Kotlin/JVM represents `String` values as UTF-16 `jstring` objects across JNI.

The existing bridge uses `GetStringUTFChars` and `NewStringUTF` for string conversion. However, these JNI APIs use Modified UTF-8, while the QuickJS C API expects standard UTF-8.

The two encodings behave similarly for ASCII and most BMP characters, but encode supplementary characters such as emoji differently:

- Standard UTF-8 encodes an emoji as a single four-byte sequence.
- Modified UTF-8 encodes its UTF-16 surrogate pair as two three-byte sequences.

Passing Modified UTF-8 through the QuickJS C API can therefore corrupt emoji and other supplementary Unicode characters.

### Changes

```text
Kotlin/JVM String
   UTF-16 jstring
         ⇅
 Shared JNI converter
         ⇅
UTF-8/WTF-8 bytes + explicit length
         ⇅
    QuickJS C API
         ⇅
JavaScript String
   UTF-16 code-unit semantics
```

- Valid Unicode content uses standard UTF-8, while unpaired UTF-16 surrogates are preserved internally with WTF-8.
- Evaluation, bindings, value mapping, exceptions, and module loading now use the shared converter.
- The CMake configuration now ensures that new JNI source files are included for every Android ABI.

### Compatibility

- No changes to the public Kotlin API, ABI, or existing call sites.
- No changes to the QuickJS string implementation.
- Existing behavior for ASCII, Chinese text, and other supported BMP characters remains unchanged.
- Emoji and other supplementary characters now use standard UTF-8 at the QuickJS C API boundary.
- WTF-8 is used only inside the JNI bridge and is never exposed as an external encoding.

### Tests

Added coverage for:

- Chinese text, combining characters, emoji, and supplementary-plane identifiers.
- JavaScript source, evaluation results, and bytecode.
- Binding names, arguments, return values, and object keys.
- Kotlin and JavaScript exception messages.
- ES module names, source, and compilation callbacks.
- Unpaired high and low UTF-16 surrogates and other string boundary cases.

### Verification

- Relevant automated tests and builds pass.
- Manually verified on macOS and Android that Unicode and emoji content is passed through and displayed correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Unicode handling across JavaScript evaluation, bindings, objects, modules, errors, and bytecode.
  * Preserved embedded NUL characters and unpaired surrogates during JavaScript–Java string conversion.
  * Improved malformed-text and conversion-failure handling with clearer error behavior.
  * Module evaluation now respects full source length and rejects embedded NULs in module names.
  * Native builds now detect added or removed source files automatically.

* **Tests**
  * Added coverage for Unicode, emoji, supplementary characters, embedded NULs, and unpaired surrogates across bridge functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->